### PR TITLE
[add#18] 캘린더뷰/캘린더 뷰 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,8 @@ dependencies {
 
     //recyclerview
     implementation 'androidx.recyclerview:recyclerview:1.3.0'
+    //viewpager2
+    implementation "androidx.viewpager2:viewpager2:1.0.0"
 
     //bnv
     implementation 'com.google.android.material:material:1.9.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         android:theme="@style/Theme.Yourweather"
         tools:targetApi="31">
         <activity
-            android:name=".presentation.SocialSignUp"
+            android:name=".presentation.Calendar"
             android:exported="false" />
         <activity
             android:name=".presentation.SignUp2"

--- a/app/src/main/java/com/umc/yourweather/presentation/Calendar.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/Calendar.kt
@@ -1,0 +1,61 @@
+package com.umc.yourweather.presentation
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.util.Log
+import androidx.viewpager2.widget.ViewPager2
+import com.umc.yourweather.R
+import com.umc.yourweather.databinding.ActivityCalendarBinding
+import com.umc.yourweather.databinding.ActivityMainBinding
+import com.umc.yourweather.presentation.adapter.CalendarMonthAdapter
+
+class Calendar : AppCompatActivity() {
+    lateinit var binding : ActivityCalendarBinding
+    lateinit var  monthrAdapter : CalendarMonthAdapter
+
+    var currentPosition = 0
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityCalendarBinding.inflate(layoutInflater)
+
+        setContentView(binding.root)
+        monthrAdapter = CalendarMonthAdapter(this)
+
+        binding.vp2Calendar.adapter = monthrAdapter
+        binding.vp2Calendar.setCurrentItem(CalendarMonthAdapter.START_POSITION, false)
+        setDateInfo()
+
+        //전으로 이동
+        binding.btnCalendarBefore.setOnClickListener {
+            currentPosition = binding.vp2Calendar.currentItem
+            binding.vp2Calendar.setCurrentItem(currentPosition - 1, true)
+            Log.d("앞으로 이동", "앞앞")
+        }
+
+        //후로 이동
+        binding.btnCalendarNext.setOnClickListener {
+            currentPosition = binding.vp2Calendar.currentItem
+            binding.vp2Calendar.setCurrentItem(currentPosition + 1, true)
+
+        }
+
+        //연월띄우기
+        binding.vp2Calendar.registerOnPageChangeCallback(object :
+            ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                Log.d("onPageSelected", "앞앞")
+                setDateInfo()
+            }
+        })
+    }
+
+    private fun setDateInfo(){
+        val currentPosition = binding.vp2Calendar.currentItem
+        val itemId = monthrAdapter.getItemId(currentPosition)
+        val year = itemId / 100L
+        val month = itemId % 100L
+        binding.tvCalendarMonth.text = month.toString() +"월"
+        binding.tvCalendarYear.text = year.toString() +"년"
+    }
+}

--- a/app/src/main/java/com/umc/yourweather/presentation/CalendarDate.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/CalendarDate.kt
@@ -1,0 +1,114 @@
+package com.umc.yourweather.presentation
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Rect
+import android.graphics.Typeface
+import android.graphics.drawable.Drawable
+import android.text.TextPaint
+import android.util.AttributeSet
+import android.util.Log
+import android.view.View
+import androidx.core.content.ContextCompat
+import androidx.core.content.res.ResourcesCompat
+import androidx.core.content.withStyledAttributes
+import com.umc.yourweather.R
+import com.umc.yourweather.util.CalendarUtils.Companion.checkSize
+import com.umc.yourweather.util.CalendarUtils.Companion.dpToPx
+import java.util.Calendar
+import java.util.Date
+
+class CalendarDate @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+    val calendarMonth : Int,
+    val date : Date
+) : View(context, attrs, defStyleAttr) {
+    val count = 1 //데이터 개수
+    lateinit var datePaint : Paint
+    lateinit var temPaint : Paint
+    var customDrawable: Drawable? = null
+    var cal = Calendar.getInstance()
+
+//    //**삭제예정!!!!!
+//    private val borderPaint = Paint().apply {
+//        color = Color.BLACK // 테두리 색상
+//        style = Paint.Style.STROKE // 선 스타일 (STROKE는 외곽선)
+//        strokeWidth = 5f // 선 두께
+//    }
+
+    init {
+        //setCustomPadding() 삭제예정
+        cal.time = date
+        if (isSameMonth() == true) {
+            context.withStyledAttributes(attrs, R.styleable.Calendar, defStyleAttr
+            ) {
+                val dateFont = ResourcesCompat.getFont(context, R.font.pretendardregular)
+                val tempFont = ResourcesCompat.getFont(context, R.font.pretendardsemibold)
+
+                datePaint = TextPaint().apply {
+                    textSize = dpToPx(context, 12)
+                    isAntiAlias = true
+                    textAlign = Paint.Align.CENTER
+                    typeface = dateFont
+                }
+
+                if (isLaterDay()){
+                    datePaint.color = Color.parseColor("#D1CAC6")
+                }else {
+                    datePaint.color = Color.parseColor("#2B2B2B")
+                    if (count > 0) {
+                        temPaint = TextPaint().apply {
+                            textSize = dpToPx(context, 12)
+                            color = Color.parseColor("#2B2B2B")
+                            typeface = Typeface.DEFAULT_BOLD
+                            isAntiAlias = true
+                            textAlign = Paint.Align.CENTER
+                            typeface = tempFont
+                        }
+                        customDrawable = ContextCompat.getDrawable(context, R.drawable.ic_cloud)
+                    }
+                }
+            }
+        }
+    }
+
+
+
+    override fun onDraw(canvas: Canvas?) {
+        super.onDraw(canvas)
+        //canvas?.drawRect(0f, 0f, width.toFloat(), height.toFloat(), borderPaint)
+        if (isSameMonth() == true) {
+            val dateText = cal.get(Calendar.DAY_OF_MONTH).toString()
+            val temp = "40" + "°"
+
+            canvas?.drawText(dateText, (width / 2).toFloat(), dpToPx(context, 16), datePaint)
+            //checkSize(datePaint, dateText)
+            if (count > 0 && !isLaterDay()) {
+                val drawableleft = (width / 2) - dpToPx(context, 24).toInt()
+                val drawableright = drawableleft + dpToPx(context, 48).toInt()
+                val drawableTop = dpToPx(context, 18).toInt()
+                val drawableBoottom = drawableTop + dpToPx(context, 48).toInt()
+                customDrawable?.let {
+                    it.setBounds(drawableleft, drawableTop, drawableright, drawableBoottom)
+                    it.draw(canvas!!)
+                }
+                canvas?.drawText(temp, (width /2).toFloat(), dpToPx(context, 70), temPaint)
+                //checkSize(temPaint, temp)
+            }
+        }
+    }
+
+    fun isSameMonth() : Boolean{
+        val month = cal.get(Calendar.MONTH) + 1
+        return month == calendarMonth
+    }
+
+    fun isLaterDay() : Boolean {
+        val todayCalendar = Calendar.getInstance()
+        return todayCalendar.before(cal)
+    }
+}

--- a/app/src/main/java/com/umc/yourweather/presentation/CalendarFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/CalendarFragment.kt
@@ -1,0 +1,46 @@
+package com.umc.yourweather.presentation
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.umc.yourweather.R
+import com.umc.yourweather.databinding.FragmentCalendarBinding
+import java.util.Calendar
+import java.util.Date
+
+class CalendarFragment : Fragment() {
+    lateinit var binding : FragmentCalendarBinding
+    lateinit var cal : Calendar
+    lateinit var todayCalendar: Calendar
+    var dateList: MutableList<Date> = mutableListOf()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        binding = FragmentCalendarBinding.inflate(layoutInflater)
+        cal = Calendar.getInstance()
+
+        val year = arguments?.getInt("year")
+        val month = arguments?.getInt("month")
+        val id = arguments?.getString("id")
+
+        cal.set(year!!, month!!-1, 1)
+        getDate(year!!, month!!)
+        binding.ctCalendarCustom.initCalendar(month!!, dateList)
+
+        return binding.root
+    }
+
+    fun getDate(year : Int, month : Int){
+        var dayOfWeek = cal.get(Calendar.DAY_OF_WEEK)//이번 달 첫날의 요일 일요일부터(1~7)
+        cal.add(Calendar.DATE, -(dayOfWeek-1))
+        for(i in 1.. 42) {
+            dateList.add(cal.time)
+            cal.add(Calendar.DATE, 1)
+        }
+    }
+}

--- a/app/src/main/java/com/umc/yourweather/presentation/CalendarMonth.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/CalendarMonth.kt
@@ -1,0 +1,47 @@
+package com.umc.yourweather.presentation
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.ViewGroup
+import androidx.core.view.children
+import com.umc.yourweather.util.CalendarUtils.Companion.DAYS_PER_WEEK
+import com.umc.yourweather.util.CalendarUtils.Companion.WEEKS_PER_MONTH
+import com.umc.yourweather.util.CalendarUtils.Companion.dpToPx
+import java.util.Date
+
+class CalendarMonth @JvmOverloads constructor(
+    context: Context,
+    val attrs: AttributeSet? = null,
+    val defStyleAttr: Int = 0) :
+    ViewGroup(context, attrs, defStyleAttr) {
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+    }
+
+    override fun onLayout(p0: Boolean, p1: Int, p2: Int, p3: Int, p4: Int) {
+        val marginHorizontal = dpToPx(context, 16).toInt()//좌우 마진
+        val marginVertical = dpToPx(context, 12).toInt() // 상하 마진 크기 (픽셀 단위)
+        var cWidth = (width - (DAYS_PER_WEEK-1) * marginHorizontal) / DAYS_PER_WEEK
+        var cHeight = (height - (WEEKS_PER_MONTH-1) * marginVertical) / WEEKS_PER_MONTH
+
+        children.forEachIndexed { index, view ->
+            val left = (index % DAYS_PER_WEEK) * (cWidth + marginHorizontal)
+            val top = (index / DAYS_PER_WEEK) * (cHeight + marginVertical)
+            //if(index)
+            view.layout(left, top, left + cWidth, top + cHeight)
+        }
+    }
+
+    fun initCalendar(month: Int, list: MutableList<Date>) {
+        list.forEach {
+            addView(
+                CalendarDate(
+                    context = context,
+                    date = it,
+                    calendarMonth = month
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/umc/yourweather/presentation/adapter/CalendarMonthAdapter.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/adapter/CalendarMonthAdapter.kt
@@ -1,0 +1,42 @@
+package com.umc.yourweather.presentation.adapter
+
+import android.os.Bundle
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.umc.yourweather.presentation.CalendarFragment
+import java.util.Calendar
+import java.util.Date
+
+class CalendarMonthAdapter (fragmentActivity: FragmentActivity) : FragmentStateAdapter(fragmentActivity){
+    companion object{
+        const val START_POSITION = Int.MAX_VALUE / 2
+    }
+
+    override fun getItemCount() : Int =  Int.MAX_VALUE
+
+    override fun createFragment (position: Int): CalendarFragment {
+        val itemId = getItemId(position).toInt()
+        return CalendarFragment().apply {
+            arguments = Bundle().apply {
+                putInt("year", itemId / 100)
+                putInt("month", itemId % 100)
+                putString("id", itemId.toString())
+            }
+        }
+    }
+
+    override fun getItemId(position: Int): Long {
+        var calendar = Calendar.getInstance()
+        calendar.time = Date()
+        calendar.set(Calendar.DAY_OF_MONTH, 1)
+        calendar.add(Calendar.MONTH, position - START_POSITION)
+
+        var currentYear = calendar.get(Calendar.YEAR)
+        var currentMonth = calendar.get(Calendar.MONTH) + 1
+        return (currentYear * 100L + currentMonth).toLong()
+    }
+
+    override fun containsItem(itemId: Long): Boolean {
+        return 190000L <= itemId && itemId <= 220000L
+    }
+}

--- a/app/src/main/res/drawable/btn_calendar_left.xml
+++ b/app/src/main/res/drawable/btn_calendar_left.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="9dp"
+    android:height="16dp"
+    android:viewportWidth="9"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M8,15L4.5,11.5L1,8L8,1"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#424242"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/btn_calendar_right.xml
+++ b/app/src/main/res/drawable/btn_calendar_right.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="9dp"
+    android:height="16dp"
+    android:viewportWidth="9"
+    android:viewportHeight="16">
+  <path
+      android:pathData="M1,15L4.5,11.5L8,8L1,1"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#424242"
+      android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/drawable/btn_calendar_year.xml
+++ b/app/src/main/res/drawable/btn_calendar_year.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="13dp"
+    android:height="13dp"
+    android:viewportWidth="13"
+    android:viewportHeight="13">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M0.5,0.5h12v12h-12z"
+      android:fillColor="#ffffff"
+      android:strokeColor="#585858"/>
+  <path
+      android:pathData="M6.5,9L10.397,4.5H2.603L6.5,9Z"
+      android:fillColor="#585858"/>
+</vector>

--- a/app/src/main/res/layout/activity_calendar.xml
+++ b/app/src/main/res/layout/activity_calendar.xml
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.Calendar">
+    <LinearLayout
+        android:id="@+id/ll_calendar_bar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:id="@+id/tv_unwritten_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="16dp"
+            android:layout_marginTop="26dp"
+            android:fontFamily="@font/pretendardbold"
+            android:text="캘린더"
+            android:textColor="#F07818"
+            android:textSize="24dp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/ll_calendar_year"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="9dp"
+        android:gravity="center"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/ll_calendar_bar">
+
+        <TextView
+            android:id="@+id/tv_calendar_year"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginRight="4dp"
+            android:fontFamily="@font/pretendardsemibold"
+            android:text="nnnn년 "
+            android:textColor="#C22B2B2B"
+            android:textSize="14dp" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_calendar_year"
+            android:layout_width="13dp"
+            android:layout_height="13dp"
+            android:background="@drawable/btn_calendar_year" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/ll_calendar_month"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="6dp"
+        android:gravity="center"
+        android:orientation="horizontal"
+        app:layout_constraintTop_toBottomOf="@+id/ll_calendar_year">
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_calendar_before"
+            android:layout_width="7dp"
+            android:layout_height="14dp"
+            android:layout_marginLeft="123dp"
+            android:background="@drawable/btn_calendar_left" />
+
+        <TextView
+            android:id="@+id/tv_calendar_month"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="38dp"
+            android:layout_marginRight="38dp"
+            android:fontFamily="@font/pretendardsemibold"
+            android:gravity="center"
+            android:text="nn 월"
+            android:textSize="16dp" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_calendar_next"
+            android:layout_width="7dp"
+            android:layout_height="14dp"
+            android:layout_marginRight="123dp"
+            android:background="@drawable/btn_calendar_right" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/ll_calendar_day"
+        android:layout_width="match_parent"
+        android:layout_height="35dp"
+        android:layout_marginTop="16dp"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/ll_calendar_month">
+
+        <TextView
+            android:id="@+id/textView6"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="#EFEFEF"
+            android:fontFamily="@font/pretendardregular"
+            android:gravity="center"
+            android:text="일"
+            android:textColor="#EB5545"
+            android:textSize="11dp" />
+
+        <TextView
+            android:id="@+id/textView8"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="#EFEFEF"
+            android:fontFamily="@font/pretendardregular"
+            android:gravity="center"
+            android:text="월"
+            android:textColor="#2B2B2B"
+            android:textSize="11dp" />
+
+        <TextView
+            android:id="@+id/textView7"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="#EFEFEF"
+            android:fontFamily="@font/pretendardregular"
+            android:gravity="center"
+            android:text="화"
+            android:textColor="#2B2B2B"
+            android:textSize="11dp" />
+
+        <TextView
+            android:id="@+id/textView5"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="#EFEFEF"
+            android:fontFamily="@font/pretendardregular"
+            android:gravity="center"
+            android:text="수"
+            android:textColor="#2B2B2B"
+            android:textSize="11dp" />
+
+        <TextView
+            android:id="@+id/textView9"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="#EFEFEF"
+            android:fontFamily="@font/pretendardregular"
+            android:gravity="center"
+            android:text="목"
+            android:textColor="#2B2B2B"
+            android:textSize="11dp" />
+
+        <TextView
+            android:id="@+id/textView10"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="#EFEFEF"
+            android:fontFamily="@font/pretendardregular"
+            android:gravity="center"
+            android:text="금"
+            android:textColor="#2B2B2B"
+            android:textSize="11dp" />
+
+        <TextView
+            android:id="@+id/textView4"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:background="#EFEFEF"
+            android:fontFamily="@font/pretendardregular"
+            android:gravity="center"
+            android:text="토"
+            android:textColor="#3D7AB9"
+            android:textSize="11dp" />
+    </LinearLayout>
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/vp2_calendar"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="20dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="50dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/ll_calendar_day" />
+
+    <View
+        android:id="@+id/view_backgroundView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="invisible"
+        android:background="#80000000" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_calendar.xml
+++ b/app/src/main/res/layout/fragment_calendar.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/tv"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".presentation.CalendarFragment">
+
+    <com.umc.yourweather.presentation.CalendarMonth
+        android:id="@+id/ct_calendar_custom"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:dayTextSize="11dp"
+        app:temTextSize="10dp"
+        >
+    </com.umc.yourweather.presentation.CalendarMonth>
+
+</LinearLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="Calendar">
+        <attr name="month" format="integer|reference"/>
+        <attr name="weatherImg" format="integer|reference"/>
+        <attr name="temTextSize" format="dimension"/>
+        <attr name="dayTextSize" format="dimension"/>
+    </declare-styleable>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,6 @@
     <string name="bnv_title3">리포트</string>
     <string name="bnv_title4">마이페이지</string>
     <string name="signup_resend"><u>인증코드 재전송</u></string>
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>


### PR DESCRIPTION
## 개요

> 캘린더 뷰 구현

## 작업 사항

- [x] 캘린더 뷰 구현


## 참고사항 및 스크린샷

[캘린더구현영상최종.webm](https://github.com/yourweather/yourweather_android/assets/109809242/2a8ffc34-ebfa-4bbc-b2d4-1786f180d9f6)

> 버튼 클릭시 해당 날짜로 이동하는 창/기능을 추가해야합니다
 gui에 pm님이 올려주신 프로토 타입에서는 버튼 클릭 시 선택창이 바로 뜨는데 안드로이드에서 제공되는 위젯들은 아래로 따라락 펼쳐지면서 뜨는 것 밖에 없더라구요,, 이것저것 시도해보다가 실패해서 이 부분은 더 알아봐야할 것 같습니다

>현재 상태로는 바텀네비게이션바 추가시 6주까지 있는 달은 아래가 잘릴 것 같습니다. gui가 수정되면 전체적인 크기 수정 들어가야할 것 같은데 이 때 상단 바도 함께 수정할 예정입니다.
