### PR TITLE
[feat/#132] initial,home / toast 메시지 생성 오류 수정

### DIFF
--- a/app/src/main/java/com/umc/yourweather/presentation/HomeFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/HomeFragment.kt
@@ -42,6 +42,7 @@ class HomeFragment : Fragment(), HomeFragmentInteractionListener {
             replace(R.id.fl_home_l1, fragment)
             addToBackStack(null)
         }
+        showHomeToast()
     }
 
     override fun goToNewHome() {

--- a/app/src/main/java/com/umc/yourweather/presentation/InitialNoWeatherFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/InitialNoWeatherFragment.kt
@@ -2,9 +2,11 @@
 package com.umc.yourweather.presentation
 
 import android.os.Bundle
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import com.umc.yourweather.R
 import com.umc.yourweather.databinding.FragmentInitialNoWeatherBinding
@@ -24,6 +26,8 @@ class InitialNoWeatherFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        showInitialToast()
+
         binding.btnInitialWeather.setOnClickListener {
             val newFragment = HomeWeatherInputFragment()
             val transaction = parentFragmentManager.beginTransaction()
@@ -31,5 +35,13 @@ class InitialNoWeatherFragment : Fragment() {
             transaction.addToBackStack(null)
             transaction.commit()
         }
+    }
+
+    private fun showInitialToast() {
+        val toastView = layoutInflater.inflate(R.layout.toast_initial, binding.root, false)
+        val toast = Toast.makeText(context, "", Toast.LENGTH_LONG)
+        toast.view = toastView
+        toast.setGravity(Gravity.BOTTOM or Gravity.CENTER, 0, resources.getDimensionPixelSize(R.dimen.initial_toast_margin_bottom))
+        toast.show()
     }
 }

--- a/app/src/main/java/com/umc/yourweather/presentation/analysis/BarStaticsMonthlyFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/analysis/BarStaticsMonthlyFragment.kt
@@ -1,5 +1,6 @@
 package com.umc.yourweather.presentation.analysis
 
+import android.graphics.Color
 import android.os.Bundle
 import android.text.Spannable
 import android.text.SpannableStringBuilder
@@ -8,6 +9,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.umc.yourweather.R
 import com.umc.yourweather.data.BarData

--- a/app/src/main/java/com/umc/yourweather/presentation/analysis/BarStaticsWeeklyFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/analysis/BarStaticsWeeklyFragment.kt
@@ -1,5 +1,6 @@
 package com.umc.yourweather.presentation.analysis
 
+import android.graphics.Color
 import android.os.Bundle
 import android.text.Spannable
 import android.text.SpannableStringBuilder


### PR DESCRIPTION
## 개요

> initialnoweather뷰 , home 뷰 toast 메시지 생성 오류 수정

## 작업 사항
- [x]  #132 
- [x] 비교분석 뷰 import 누락된 부분 추가 

## 참고사항 및 스크린샷
### 홈화면 토스트 메시지 관련해서는 용량 문제로 인해 카톡방에 올려두겠습니다 !
**아래는 initial 화면 토스트 메시지 영상입니다.**

[yourweather_initialtoast.webm](https://github.com/yourweather/yourweather_android/assets/102938120/b1d757a9-47c9-4b56-8b9a-660da72497bd)