### PR TITLE
[style/#143] 소셜로그인 크기 변경

### DIFF
--- a/app/src/main/java/com/umc/yourweather/presentation/sign/Nickname.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/sign/Nickname.kt
@@ -1,17 +1,22 @@
 package com.umc.yourweather.presentation.sign
 
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Button
 import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import com.umc.yourweather.R
+import com.umc.yourweather.databinding.ActivityNicknameBinding
+import com.umc.yourweather.presentation.BottomNavi
 import com.umc.yourweather.util.NicknameUtils.Companion.getRandomHintText
 
 class Nickname : AppCompatActivity() {
 
+    lateinit var binding: ActivityNicknameBinding
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_nickname)
+        binding = ActivityNicknameBinding.inflate(layoutInflater)
+        setContentView(binding.root)
 
         val editText: EditText = findViewById(R.id.et_nickname_nickname)
         val button: Button = findViewById(R.id.btn_nickname_refresh)
@@ -20,6 +25,11 @@ class Nickname : AppCompatActivity() {
         button.setOnClickListener {
             editText.setText("")
             editText.hint = getRandomHintText()
+        }
+
+        binding.btnNicknameNext.setOnClickListener {
+            val mIntent = Intent(this, BottomNavi::class.java)
+            startActivity(mIntent)
         }
     }
 }

--- a/app/src/main/java/com/umc/yourweather/presentation/sign/SignIn.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/sign/SignIn.kt
@@ -27,7 +27,7 @@ class SignIn : AppCompatActivity() {
         }
 
         binding.tvSigninBtnsignup.setOnClickListener {
-            customToast()
+            // customToast()
             val mIntent = Intent(this, SignUp::class.java)
             startActivity(mIntent)
         }

--- a/app/src/main/java/com/umc/yourweather/presentation/sign/SignUp2.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/sign/SignUp2.kt
@@ -28,7 +28,6 @@ class SignUp2 : AppCompatActivity() {
             startActivity(mIntent)
             finish()
         }
-
         binding.etSignup2Pw.addTextChangedListener(createTextWatcher(::checkPwFormat))
         binding.etSignup2Repw.addTextChangedListener(createTextWatcher(::checkRePw))
     }

--- a/app/src/main/res/layout/activity_sign_in.xml
+++ b/app/src/main/res/layout/activity_sign_in.xml
@@ -149,7 +149,7 @@
     <LinearLayout
         android:id="@+id/ll_signin_socialbtns"
         android:layout_width="0dp"
-        android:layout_height="34dp"
+        android:layout_height="wrap_content"
         android:layout_marginStart="112dp"
         android:layout_marginTop="24dp"
         android:layout_marginEnd="112dp"
@@ -162,23 +162,23 @@
 
         <ImageView
             android:id="@+id/btn_signin_naver"
-            android:layout_width="34dp"
-            android:layout_height="34dp"
+            android:layout_width="38dp"
+            android:layout_height="38dp"
             android:scaleType="centerInside"
             app:srcCompat="@drawable/ic_signin_naver" />
 
         <ImageView
             android:id="@+id/btn_signin_kakao"
-            android:layout_width="34dp"
-            android:layout_height="wrap_content"
+            android:layout_width="38dp"
+            android:layout_height="38dp"
             android:layout_marginLeft="17dp"
             android:layout_marginRight="17dp"
             app:srcCompat="@drawable/ic_signin_kakao" />
 
         <ImageView
             android:id="@+id/btn_signin_google"
-            android:layout_width="34dp"
-            android:layout_height="34dp"
+            android:layout_width="38dp"
+            android:layout_height="38dp"
             app:srcCompat="@drawable/ic_signin_google" />
 
     </LinearLayout>


### PR DESCRIPTION
## 개요

> 소셜로그인 버튼 크기 조정 

## 작업 사항

- [x]  소셜로그인 버튼 크기 조정 
- [x] 로그인->회원가입시 뜨는 경고 토스트 주석처리
- [x] 닉네임뷰->초기화면 이동 로직 추가

## 참고사항 및 스크린샷

소셜 로그인 버튼 34*34로 해두었었는데 너무 작아서 38*38로 바꾸었습니다!
소셜로그인 버튼 크기는 디스코드에 올려두었습니다

https://github.com/yourweather/yourweather_android/assets/109809242/6d33abec-3c3e-4e1e-a90f-557ebe29f3ce



 