### PR TITLE
[fix/#146] home / 홈화면 toast메시지 생성 시점 오류 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,13 +14,13 @@
         tools:targetApi="31">
 
         <activity
-            android:name=".presentation.InitialNoWeatherFragment"
+            android:name=".presentation.weatherinput.InitialNoWeatherFragment"
             android:exported="true"/>
         <activity
-            android:name=".presentation.HomeFragment"
+            android:name=".presentation.weatherinput.HomeFragment"
             android:exported="true" />
         <activity
-            android:name=".presentation.HomeWeatherInputFragment"
+            android:name=".presentation.weatherinput.HomeWeatherInputFragment"
             android:exported="true" />
         <activity
             android:name=".presentation.MyPagePwChange"

--- a/app/src/main/java/com/umc/yourweather/presentation/BottomNavi.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/BottomNavi.kt
@@ -9,6 +9,7 @@ import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.umc.yourweather.R
 import com.umc.yourweather.presentation.calendar.CalendarTotalViewFragment
 import com.umc.yourweather.presentation.analysis.AnalysisFragment
+import com.umc.yourweather.presentation.weatherinput.InitialNoWeatherFragment
 
 
 class BottomNavi : AppCompatActivity() {

--- a/app/src/main/java/com/umc/yourweather/presentation/weatherinput/HomeFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/weatherinput/HomeFragment.kt
@@ -1,4 +1,4 @@
-package com.umc.yourweather.presentation
+package com.umc.yourweather.presentation.weatherinput
 
 import android.os.Bundle
 import android.util.Log

--- a/app/src/main/java/com/umc/yourweather/presentation/weatherinput/HomeFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/weatherinput/HomeFragment.kt
@@ -33,6 +33,7 @@ class HomeFragment : Fragment(), HomeFragmentInteractionListener {
         binding.btnHomeWeatherinput.setOnClickListener {
             openHomeWeatherInputFragment()
         }
+        showHomeToast()
     }
 
     private fun openHomeWeatherInputFragment() {
@@ -42,7 +43,6 @@ class HomeFragment : Fragment(), HomeFragmentInteractionListener {
             replace(R.id.fl_home_l1, fragment)
             addToBackStack(null)
         }
-        showHomeToast()
     }
 
     override fun goToNewHome() {

--- a/app/src/main/java/com/umc/yourweather/presentation/weatherinput/HomeFragmentInteractionListener.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/weatherinput/HomeFragmentInteractionListener.kt
@@ -1,4 +1,4 @@
-package com.umc.yourweather.presentation
+package com.umc.yourweather.presentation.weatherinput
 
 interface HomeFragmentInteractionListener {
     fun goToNewHome()

--- a/app/src/main/java/com/umc/yourweather/presentation/weatherinput/HomeWeatherInputFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/weatherinput/HomeWeatherInputFragment.kt
@@ -1,4 +1,4 @@
-package com.umc.yourweather.presentation
+package com.umc.yourweather.presentation.weatherinput
 
 import android.os.Bundle
 import android.view.LayoutInflater

--- a/app/src/main/java/com/umc/yourweather/presentation/weatherinput/InitialNoWeatherFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/weatherinput/InitialNoWeatherFragment.kt
@@ -1,5 +1,5 @@
 
-package com.umc.yourweather.presentation
+package com.umc.yourweather.presentation.weatherinput
 
 import android.os.Bundle
 import android.view.Gravity

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -5,7 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".presentation.Home">
+    tools:context=".presentation.weatherinput.Home">
 
     <FrameLayout
         android:id="@+id/fl_home_l1"

--- a/app/src/main/res/layout/fragment_home_weather_input.xml
+++ b/app/src/main/res/layout/fragment_home_weather_input.xml
@@ -5,7 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="#CC000000"
-    tools:context=".presentation.HomeWeatherInputFragment">
+    tools:context=".presentation.weatherinput.HomeWeatherInputFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_initial_no_weather.xml
+++ b/app/src/main/res/layout/fragment_initial_no_weather.xml
@@ -5,7 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".presentation.InitialNoWeatherFragment">
+    tools:context=".presentation.weatherinput.InitialNoWeatherFragment">
 
     <FrameLayout
         android:id="@+id/fl_initial_l1"


### PR DESCRIPTION
## 개요

> 홈화면 toast 메시지 생성 시점 오류 수정 
 
## 작업 사항
- [x]  #146 
- [x] 폴더 구조 정리 
 **initial, home, homeweatherinput 모두 날씨입력이라는 공통점을 가지고 있어서 weatherinput 이라는 패키지로 묶었습니다 !** 

## 참고사항 및 스크린샷
toast메시지 관련 영상은 앞서 보낸 카톡에 공유한 대로 조정했습니다 !

![image](https://github.com/yourweather/yourweather_android/assets/102938120/f38549ac-1f49-4d5e-8962-e7b0731320c2)
