### PR TITLE
[feat/#144] 비교분석뷰 / 날씨 말풍선 구현

### DIFF
--- a/app/src/main/java/com/umc/yourweather/presentation/analysis/BarStaticsMonthlyFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/analysis/BarStaticsMonthlyFragment.kt
@@ -2,6 +2,7 @@ package com.umc.yourweather.presentation.analysis
 
 import android.graphics.Color
 import android.os.Bundle
+import android.os.Handler
 import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.style.ForegroundColorSpan
@@ -62,15 +63,17 @@ class BarStaticsMonthlyFragment : Fragment() {
         val dataList = listOf(
             BarData("맑음", 44),
             BarData("흐림", 29),
-            BarData("번개", 59),
             BarData("비", 24),
+            BarData("번개", 59),
+
         )
 
         val dataList2 = listOf(
             BarData("맑음", 14),
             BarData("흐림", 43),
-            BarData("번개", 20),
             BarData("비", 66),
+            BarData("번개", 20),
+
         )
 
         // 각 데이터 값에 해당하는 너비 계산
@@ -91,13 +94,18 @@ class BarStaticsMonthlyFragment : Fragment() {
             val drawableRes = when (data.label) {
                 "맑음" -> R.drawable.bg_yellow_rec_round_sun
                 "흐림" -> R.drawable.bg_gray_rec_cloud
-                "번개" -> R.drawable.bg_blue_rec_rain
-                "비" -> R.drawable.bg_darkblue_rec_round_thunder
-                else -> R.drawable.bg_gray_rec_cloud
+                "비" -> R.drawable.bg_blue_rec_rain
+                "번개" -> R.drawable.bg_darkblue_rec_round_thunder
+                else -> -1
             }
 
             view.background = ContextCompat.getDrawable(requireContext(), drawableRes)
             binding.llAnalysisBarLastMonth.addView(view)
+
+            // 클릭 시 말풍선 보이게
+            view.setOnClickListener {
+                showBallView(data.label)
+            }
         }
 
         for (data in dataList2) {
@@ -116,16 +124,83 @@ class BarStaticsMonthlyFragment : Fragment() {
             val drawableRes = when (data.label) {
                 "맑음" -> R.drawable.bg_yellow_rec_round_sun
                 "흐림" -> R.drawable.bg_gray_rec_cloud
-                "번개" -> R.drawable.bg_blue_rec_rain
-                "비" -> R.drawable.bg_darkblue_rec_round_thunder
-                else -> R.drawable.bg_gray_rec_cloud
+                "비" -> R.drawable.bg_blue_rec_rain
+                "번개" -> R.drawable.bg_darkblue_rec_round_thunder
+
+                else -> -1
             }
 
             view.background = ContextCompat.getDrawable(requireContext(), drawableRes)
             binding.llAnalysisBarThisMonth.addView(view)
+
+            // 클릭 시 말풍선 보이게
+            view.setOnClickListener {
+                showBallViewThisMonth(data.label)
+            }
         }
     }
 
+    private fun showBallView(weatherLabel: String) {
+        // 모든 텍스트뷰 숨기기
+        binding.tvBalloonSun.visibility = View.GONE
+        binding.tvBalloonRain.visibility = View.GONE
+        binding.tvBalloonCloud.visibility = View.GONE
+        binding.tvBalloonThunder.visibility = View.GONE
+
+        // 선택한 날씨에 맞는 TextView를 보이도록 설정
+        when (weatherLabel) {
+            "맑음" -> {
+                binding.tvBalloonSun.visibility = View.VISIBLE
+                hideBallViewAfterDelay(binding.tvBalloonSun)
+            }
+            "흐림" -> {
+                binding.tvBalloonCloud.visibility = View.VISIBLE
+                hideBallViewAfterDelay(binding.tvBalloonCloud)
+            }
+            "번개" -> {
+                binding.tvBalloonThunder.visibility = View.VISIBLE
+                hideBallViewAfterDelay(binding.tvBalloonThunder)
+            }
+            "비" -> {
+                binding.tvBalloonRain.visibility = View.VISIBLE
+                hideBallViewAfterDelay(binding.tvBalloonRain)
+            }
+        }
+    }
+
+    private fun showBallViewThisMonth(weatherLabel: String) {
+        // 모든 텍스트뷰 숨기기
+        binding.tvBalloonSunThis.visibility = View.GONE
+        binding.tvBalloonRainThis.visibility = View.GONE
+        binding.tvBalloonCloudThis.visibility = View.GONE
+        binding.tvBalloonThunderThis.visibility = View.GONE
+
+        // 선택한 날씨에 맞는 TextView를 보이도록 설정
+        when (weatherLabel) {
+            "맑음" -> {
+                binding.tvBalloonSunThis.visibility = View.VISIBLE
+                hideBallViewAfterDelay(binding.tvBalloonSunThis)
+            }
+            "흐림" -> {
+                binding.tvBalloonCloudThis.visibility = View.VISIBLE
+                hideBallViewAfterDelay(binding.tvBalloonCloudThis)
+            }
+            "번개" -> {
+                binding.tvBalloonThunderThis.visibility = View.VISIBLE
+                hideBallViewAfterDelay(binding.tvBalloonThunderThis)
+            }
+            "비" -> {
+                binding.tvBalloonRainThis.visibility = View.VISIBLE
+                hideBallViewAfterDelay(binding.tvBalloonRainThis)
+            }
+        }
+    }
+    private fun hideBallViewAfterDelay(view: View) {
+        val handler = Handler()
+        handler.postDelayed({
+            view.visibility = View.GONE
+        }, 1500) // 1.5초 후에 말풍선을 숨김
+    }
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null

--- a/app/src/main/java/com/umc/yourweather/presentation/analysis/BarStaticsWeeklyFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/analysis/BarStaticsWeeklyFragment.kt
@@ -2,6 +2,7 @@ package com.umc.yourweather.presentation.analysis
 
 import android.graphics.Color
 import android.os.Bundle
+import android.os.Handler
 import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.style.ForegroundColorSpan
@@ -62,15 +63,15 @@ class BarStaticsWeeklyFragment : Fragment() {
         val dataList = listOf(
             BarData("맑음", 44),
             BarData("흐림", 60),
-            BarData("번개", 100),
             BarData("비", 24),
-        )
+            BarData("번개", 100),
+            )
 
         val dataList2 = listOf(
             BarData("맑음", 100),
             BarData("흐림", 34),
-            BarData("번개", 20),
             BarData("비", 66),
+            BarData("번개", 20),
         )
 
         // 각 데이터 값에 해당하는 너비 계산
@@ -91,13 +92,18 @@ class BarStaticsWeeklyFragment : Fragment() {
             val drawableRes = when (data.label) {
                 "맑음" -> R.drawable.bg_yellow_rec_round_sun
                 "흐림" -> R.drawable.bg_gray_rec_cloud
-                "번개" -> R.drawable.bg_blue_rec_rain
-                "비" -> R.drawable.bg_darkblue_rec_round_thunder
+                "비" -> R.drawable.bg_blue_rec_rain
+                "번개" -> R.drawable.bg_darkblue_rec_round_thunder
                 else -> R.drawable.bg_gray_rec_cloud
             }
 
             view.background = ContextCompat.getDrawable(requireContext(), drawableRes)
             binding.llAnalysisBarLastWeek.addView(view)
+
+            // 클릭 시 말풍선 보이게
+            view.setOnClickListener {
+                showBallViewLastWeek(data.label)
+            }
         }
 
         for (data in dataList2) {
@@ -115,16 +121,81 @@ class BarStaticsWeeklyFragment : Fragment() {
             val drawableRes = when (data.label) {
                 "맑음" -> R.drawable.bg_yellow_rec_round_sun
                 "흐림" -> R.drawable.bg_gray_rec_cloud
-                "번개" -> R.drawable.bg_blue_rec_rain
-                "비" -> R.drawable.bg_darkblue_rec_round_thunder
+                "비" -> R.drawable.bg_blue_rec_rain
+                "번개" -> R.drawable.bg_darkblue_rec_round_thunder
                 else -> R.drawable.bg_gray_rec_cloud
             }
 
             view.background = ContextCompat.getDrawable(requireContext(), drawableRes)
             binding.llAnalysisBarThisWeek.addView(view)
+
+            // 클릭 시 말풍선 보이게
+            view.setOnClickListener {
+                showBallViewThisWeek(data.label)
+            }
+        }
+    }
+    private fun showBallViewLastWeek(weatherLabel: String) {
+        // 모든 텍스트뷰 숨기기
+        binding.tvBalloonSunLastWeek.visibility = View.GONE
+        binding.tvBalloonRainLastWeek.visibility = View.GONE
+        binding.tvBalloonCloudLastWeek.visibility = View.GONE
+        binding.tvBalloonThunderLastWeek.visibility = View.GONE
+
+        // 선택한 날씨에 맞는 TextView를 보이도록 설정
+        when (weatherLabel) {
+            "맑음" -> {
+                binding.tvBalloonSunLastWeek.visibility = View.VISIBLE
+                hideBallViewAfterDelay(binding.tvBalloonSunLastWeek)
+            }
+            "흐림" -> {
+                binding.tvBalloonCloudLastWeek.visibility = View.VISIBLE
+                hideBallViewAfterDelay(binding.tvBalloonCloudLastWeek)
+            }
+            "번개" -> {
+                binding.tvBalloonThunderLastWeek.visibility = View.VISIBLE
+                hideBallViewAfterDelay(binding.tvBalloonThunderLastWeek)
+            }
+            "비" -> {
+                binding.tvBalloonRainLastWeek.visibility = View.VISIBLE
+                hideBallViewAfterDelay(binding.tvBalloonRainLastWeek)
+            }
         }
     }
 
+    private fun showBallViewThisWeek(weatherLabel: String) {
+        // 모든 텍스트뷰 숨기기
+        binding.tvBalloonSunThisWeek.visibility = View.GONE
+        binding.tvBalloonRainThisWeek.visibility = View.GONE
+        binding.tvBalloonCloudThisWeek.visibility = View.GONE
+        binding.tvBalloonThunderThisWeek.visibility = View.GONE
+
+        // 선택한 날씨에 맞는 TextView를 보이도록 설정
+        when (weatherLabel) {
+            "맑음" -> {
+                binding.tvBalloonSunThisWeek.visibility = View.VISIBLE
+                hideBallViewAfterDelay(binding.tvBalloonSunThisWeek)
+            }
+            "흐림" -> {
+                binding.tvBalloonCloudThisWeek.visibility = View.VISIBLE
+                hideBallViewAfterDelay(binding.tvBalloonCloudThisWeek)
+            }
+            "번개" -> {
+                binding.tvBalloonThunderThisWeek.visibility = View.VISIBLE
+                hideBallViewAfterDelay(binding.tvBalloonThunderThisWeek)
+            }
+            "비" -> {
+                binding.tvBalloonRainThisWeek.visibility = View.VISIBLE
+                hideBallViewAfterDelay(binding.tvBalloonRainThisWeek)
+            }
+        }
+    }
+    private fun hideBallViewAfterDelay(view: View) {
+        val handler = Handler()
+        handler.postDelayed({
+            view.visibility = View.GONE
+        }, 1500) // 1.5초 후에 말풍선을 숨김
+    }
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null

--- a/app/src/main/res/drawable/bg_gray_balloon.xml
+++ b/app/src/main/res/drawable/bg_gray_balloon.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="52dp"
+    android:height="31dp"
+    android:viewportWidth="52"
+    android:viewportHeight="31">
+  <path
+      android:pathData="M26,0L33.794,8.25H18.206L26,0Z"
+      android:fillColor="#E4E4E4"/>
+  <path
+      android:pathData="M8,8.5L44,8.5A6.5,6.5 0,0 1,50.5 15L50.5,23A6.5,6.5 0,0 1,44 29.5L8,29.5A6.5,6.5 0,0 1,1.5 23L1.5,15A6.5,6.5 0,0 1,8 8.5z"
+      android:strokeWidth="3"
+      android:fillColor="#E4E4E4"
+      android:strokeColor="#E4E4E4"/>
+</vector>

--- a/app/src/main/res/layout/fragment_bar_statics_monthly.xml
+++ b/app/src/main/res/layout/fragment_bar_statics_monthly.xml
@@ -4,8 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".presentation.analysis.BarStaticsMonthlyFragment"
-    >
+    tools:context=".presentation.analysis.BarStaticsMonthlyFragment">
 
     <TextView
         android:id="@+id/tv_unwritten_title"
@@ -13,10 +12,10 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
+        android:fontFamily="@font/pretendardextrabold"
         android:text="@string/tv_unwritten_title"
         android:textColor="@color/black"
         android:textSize="15dp"
-        android:fontFamily="@font/pretendardextrabold"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -36,9 +35,9 @@
             android:layout_height="wrap_content"
             android:layout_marginLeft="10dp"
             android:layout_weight="1"
+            android:fontFamily="@font/pretendardsemibold"
             android:text="@string/tv_analysis_lastmonth"
-            android:textSize="15dp"
-            android:fontFamily="@font/pretendardsemibold" />
+            android:textSize="15dp" />
 
         <TextView
             android:id="@+id/tv_analysis_month_num"
@@ -46,10 +45,10 @@
             android:layout_height="wrap_content"
             android:layout_marginLeft="7dp"
             android:layout_weight="1"
-            android:text="6월"
-            android:textSize="12dp"
+            android:fontFamily="@font/pretendardmedium"
             android:gravity="top"
-            android:fontFamily="@font/pretendardmedium"/>
+            android:text="6월"
+            android:textSize="12dp" />
         <!--데이터 바인딩으로 상세 달 입력 받는 것 추후 추가 필요-->
 
     </LinearLayout>
@@ -59,20 +58,87 @@
         android:id="@+id/ll_analysis_bar_last_month"
         android:layout_width="match_parent"
         android:layout_height="32dp"
-        android:layout_marginTop="11dp"
-        android:layout_marginBottom="32dp"
         android:layout_marginStart="33dp"
+        android:layout_marginTop="11dp"
         android:layout_marginEnd="32dp"
+        android:layout_marginBottom="32dp"
+        android:orientation="horizontal"
         app:layout_constraintBottom_toTopOf="@+id/ll_analysis_weather2"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.357"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/ll_analysis_weather1"
-        app:layout_constraintVertical_bias="0.529"
-        android:orientation="horizontal"
-        >
+        app:layout_constraintVertical_bias="0.529">
 
     </LinearLayout>
+
+
+    <TextView
+        android:id="@+id/tv_balloon_sun"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-4dp"
+        android:layout_marginEnd="250dp"
+        android:background="@drawable/bg_gray_balloon"
+        android:gravity="center"
+        android:text="맑음"
+        android:fontFamily="@font/pretendardmedium"
+        android:textColor="@android:color/black"
+        android:textSize="13dp"
+        android:paddingTop="6dp"
+        app:layout_constraintEnd_toEndOf="@+id/ll_analysis_bar_last_month"
+        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_bar_last_month"
+        android:visibility="gone"/>
+    <TextView
+        android:id="@+id/tv_balloon_cloud"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-4dp"
+        android:layout_marginEnd="180dp"
+        android:background="@drawable/bg_gray_balloon"
+        android:gravity="center"
+        android:text="흐림"
+        android:fontFamily="@font/pretendardmedium"
+        android:textColor="@android:color/black"
+        android:textSize="13dp"
+        android:paddingTop="6dp"
+        app:layout_constraintEnd_toEndOf="@+id/ll_analysis_bar_last_month"
+        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_bar_last_month"
+        android:visibility="gone"/>
+    <TextView
+        android:id="@+id/tv_balloon_rain"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-4dp"
+        android:layout_marginEnd="120dp"
+        android:background="@drawable/bg_gray_balloon"
+        android:gravity="center"
+        android:text="비"
+        android:fontFamily="@font/pretendardmedium"
+        android:textColor="@android:color/black"
+        android:textSize="13dp"
+        android:paddingTop="6dp"
+        app:layout_constraintEnd_toEndOf="@+id/ll_analysis_bar_last_month"
+        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_bar_last_month"
+        android:visibility="gone"/>
+
+
+    <TextView
+        android:id="@+id/tv_balloon_thunder"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-4dp"
+        android:layout_marginEnd="20dp"
+        android:background="@drawable/bg_gray_balloon"
+        android:fontFamily="@font/pretendardmedium"
+        android:gravity="center"
+        android:paddingTop="6dp"
+        android:text="번개"
+        android:textColor="@android:color/black"
+        android:textSize="13dp"
+        app:layout_constraintEnd_toEndOf="@+id/ll_analysis_bar_last_month"
+        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_bar_last_month"
+        android:visibility="gone"/>
 
     <LinearLayout
         android:id="@+id/ll_analysis_weather2"
@@ -90,9 +156,9 @@
             android:layout_height="wrap_content"
             android:layout_marginLeft="10dp"
             android:layout_weight="1"
+            android:fontFamily="@font/pretendardsemibold"
             android:text="@string/tv_analysis_this_month"
-            android:textSize="15dp"
-            android:fontFamily="@font/pretendardsemibold" />
+            android:textSize="15dp" />
 
         <TextView
             android:id="@+id/tv_analysis_month_this_num"
@@ -100,10 +166,10 @@
             android:layout_height="wrap_content"
             android:layout_marginLeft="7dp"
             android:layout_weight="1"
-            android:text="7월"
-            android:textSize="12dp"
+            android:fontFamily="@font/pretendardmedium"
             android:gravity="top"
-            android:fontFamily="@font/pretendardmedium"/>
+            android:text="7월"
+            android:textSize="12dp" />
         <!--데이터 바인딩으로 상세 달 입력 받는 것 추후 추가 필요-->
 
 
@@ -113,16 +179,82 @@
         android:id="@+id/ll_analysis_bar_this_month"
         android:layout_width="match_parent"
         android:layout_height="32dp"
-        android:layout_marginTop="11dp"
         android:layout_marginLeft="33dp"
+        android:layout_marginTop="11dp"
         android:layout_marginRight="32dp"
         android:orientation="horizontal"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.357"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_weather2" >
+        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_weather2">
 
     </LinearLayout>
+
+    <TextView
+        android:id="@+id/tv_balloon_sun_this"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-4dp"
+        android:layout_marginEnd="300dp"
+        android:background="@drawable/bg_gray_balloon"
+        android:gravity="center"
+        android:text="맑음"
+        android:fontFamily="@font/pretendardmedium"
+        android:textColor="@android:color/black"
+        android:textSize="13dp"
+        android:paddingTop="6dp"
+        app:layout_constraintEnd_toEndOf="@+id/ll_analysis_bar_this_month"
+        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_bar_this_month"
+        android:visibility="gone"/>
+    <TextView
+        android:id="@+id/tv_balloon_cloud_this"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-4dp"
+        android:layout_marginEnd="250dp"
+        android:background="@drawable/bg_gray_balloon"
+        android:gravity="center"
+        android:text="흐림"
+        android:fontFamily="@font/pretendardmedium"
+        android:textColor="@android:color/black"
+        android:textSize="13dp"
+        android:paddingTop="6dp"
+        app:layout_constraintEnd_toEndOf="@+id/ll_analysis_bar_this_month"
+        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_bar_this_month"
+        android:visibility="gone"/>
+    <TextView
+        android:id="@+id/tv_balloon_rain_this"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-4dp"
+        android:layout_marginEnd="120dp"
+        android:background="@drawable/bg_gray_balloon"
+        android:gravity="center"
+        android:text="비"
+        android:fontFamily="@font/pretendardmedium"
+        android:textColor="@android:color/black"
+        android:textSize="13dp"
+        android:paddingTop="6dp"
+        app:layout_constraintEnd_toEndOf="@+id/ll_analysis_bar_this_month"
+        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_bar_this_month"
+        android:visibility="gone"/>
+    <TextView
+        android:id="@+id/tv_balloon_thunder_this"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-4dp"
+        android:layout_marginEnd="10dp"
+        android:background="@drawable/bg_gray_balloon"
+        android:gravity="center"
+        android:text="번개"
+        android:fontFamily="@font/pretendardmedium"
+        android:textColor="@android:color/black"
+        android:textSize="13dp"
+        android:paddingTop="6dp"
+        app:layout_constraintEnd_toEndOf="@+id/ll_analysis_bar_this_month"
+        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_bar_this_month"
+        android:visibility="gone"/>
+
 
     <LinearLayout
         android:id="@+id/linearLayout4"
@@ -142,10 +274,10 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="14dp"
+            android:fontFamily="@font/pretendardbold"
             android:gravity="center"
             android:text="@string/tv_statics_comparison_title"
-            android:fontFamily="@font/pretendardbold"
-            android:textSize="12dp"/>
+            android:textSize="12dp" />
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -157,8 +289,7 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:orientation="horizontal"
-                >
+                android:orientation="horizontal">
 
                 <ImageView
                     android:id="@+id/iv_bar_statics_uparrow1"
@@ -177,19 +308,19 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="48dp"
                     android:layout_marginTop="10dp"
-                    android:layout_marginBottom="5dp"                    android:layout_marginRight="20dp"
+                    android:layout_marginRight="20dp"
+                    android:layout_marginBottom="5dp"
                     android:layout_weight="1"
+                    android:fontFamily="@font/pretendardregular"
                     android:gravity="left"
                     android:text="맑음 비율이 20% 증가했습니다."
-                    android:fontFamily="@font/pretendardregular"
                     android:textSize="11dp" />
             </LinearLayout>
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:orientation="horizontal"
-                >
+                android:orientation="horizontal">
 
                 <ImageView
                     android:id="@+id/iv_bar_statics_uparrow2"
@@ -208,18 +339,18 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="48dp"
                     android:layout_marginTop="5dp"
-                    android:layout_marginBottom="4dp"                    android:layout_weight="1"
+                    android:layout_marginBottom="4dp"
+                    android:layout_weight="1"
+                    android:fontFamily="@font/pretendardregular"
                     android:gravity="left"
                     android:text="다소 흐림 비율이 10% 증가했습니다."
-                    android:textSize="11dp"
-                    android:fontFamily="@font/pretendardregular"/>
+                    android:textSize="11dp" />
             </LinearLayout>
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:orientation="horizontal"
-                >
+                android:orientation="horizontal">
 
                 <ImageView
                     android:id="@+id/iv_bar_statics_downarrow1"
@@ -240,19 +371,19 @@
                     android:layout_height="wrap_content"
                     android:layout_marginStart="48dp"
                     android:layout_marginTop="4dp"
-                    android:layout_marginBottom="5dp"                    android:layout_weight="1"
+                    android:layout_marginBottom="5dp"
+                    android:layout_weight="1"
+                    android:fontFamily="@font/pretendardregular"
                     android:gravity="left"
                     android:text="비 비율이 5% 감소했습니다."
-                    android:textSize="11dp"
-                    android:fontFamily="@font/pretendardregular"/>
+                    android:textSize="11dp" />
             </LinearLayout>
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:orientation="horizontal"
                 android:layout_gravity="center"
-                >
+                android:orientation="horizontal">
 
                 <ImageView
                     android:id="@+id/iv_bar_statics_downarrow2"
@@ -275,10 +406,10 @@
                     android:layout_marginTop="4dp"
                     android:layout_marginBottom="10dp"
                     android:layout_weight="1"
+                    android:fontFamily="@font/pretendardregular"
                     android:gravity="left"
                     android:text="번개 비율이 10% 감소했습니다."
-                    android:textSize="11dp"
-                    android:fontFamily="@font/pretendardregular"/>
+                    android:textSize="11dp" />
             </LinearLayout>
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_bar_statics_weekly.xml
+++ b/app/src/main/res/layout/fragment_bar_statics_weekly.xml
@@ -72,6 +72,73 @@
         android:orientation="horizontal">
         </LinearLayout>
 
+    <TextView
+        android:id="@+id/tv_balloon_sun_last_week"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-4dp"
+        android:layout_marginEnd="250dp"
+        android:background="@drawable/bg_gray_balloon"
+        android:gravity="center"
+        android:text="맑음"
+        android:fontFamily="@font/pretendardmedium"
+        android:textColor="@android:color/black"
+        android:textSize="13dp"
+        android:paddingTop="6dp"
+        app:layout_constraintEnd_toEndOf="@+id/ll_analysis_bar_last_week"
+        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_bar_last_week"
+        android:visibility="gone"/>
+    <TextView
+        android:id="@+id/tv_balloon_cloud_last_week"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-4dp"
+        android:layout_marginEnd="180dp"
+        android:background="@drawable/bg_gray_balloon"
+        android:gravity="center"
+        android:text="흐림"
+        android:fontFamily="@font/pretendardmedium"
+        android:textColor="@android:color/black"
+        android:textSize="13dp"
+        android:paddingTop="6dp"
+        app:layout_constraintEnd_toEndOf="@+id/ll_analysis_bar_last_week"
+        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_bar_last_week"
+        android:visibility="gone"/>
+    <TextView
+        android:id="@+id/tv_balloon_rain_last_week"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-4dp"
+        android:layout_marginEnd="120dp"
+        android:background="@drawable/bg_gray_balloon"
+        android:gravity="center"
+        android:text="비"
+        android:fontFamily="@font/pretendardmedium"
+        android:textColor="@android:color/black"
+        android:textSize="13dp"
+        android:paddingTop="6dp"
+        app:layout_constraintEnd_toEndOf="@+id/ll_analysis_bar_last_week"
+        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_bar_last_week"
+        android:visibility="gone"/>
+
+
+    <TextView
+        android:id="@+id/tv_balloon_thunder_last_week"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-4dp"
+        android:layout_marginEnd="20dp"
+        android:background="@drawable/bg_gray_balloon"
+        android:fontFamily="@font/pretendardmedium"
+        android:gravity="center"
+        android:paddingTop="6dp"
+        android:text="번개"
+        android:textColor="@android:color/black"
+        android:textSize="13dp"
+        app:layout_constraintEnd_toEndOf="@+id/ll_analysis_bar_last_week"
+        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_bar_last_week"
+        android:visibility="gone"/>
+
     <LinearLayout
         android:id="@+id/ll_analysis_weather2"
         android:layout_width="wrap_content"
@@ -120,6 +187,73 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/ll_analysis_weather2" >
     </LinearLayout>
+
+    <TextView
+        android:id="@+id/tv_balloon_sun_this_week"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-4dp"
+        android:layout_marginEnd="250dp"
+        android:background="@drawable/bg_gray_balloon"
+        android:gravity="center"
+        android:text="맑음"
+        android:fontFamily="@font/pretendardmedium"
+        android:textColor="@android:color/black"
+        android:textSize="13dp"
+        android:paddingTop="6dp"
+        app:layout_constraintEnd_toEndOf="@+id/ll_analysis_bar_this_Week"
+        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_bar_this_Week"
+        android:visibility="gone"/>
+    <TextView
+        android:id="@+id/tv_balloon_cloud_this_week"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-4dp"
+        android:layout_marginEnd="180dp"
+        android:background="@drawable/bg_gray_balloon"
+        android:gravity="center"
+        android:text="흐림"
+        android:fontFamily="@font/pretendardmedium"
+        android:textColor="@android:color/black"
+        android:textSize="13dp"
+        android:paddingTop="6dp"
+        app:layout_constraintEnd_toEndOf="@+id/ll_analysis_bar_this_Week"
+        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_bar_this_Week"
+        android:visibility="gone"/>
+    <TextView
+        android:id="@+id/tv_balloon_rain_this_week"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-4dp"
+        android:layout_marginEnd="120dp"
+        android:background="@drawable/bg_gray_balloon"
+        android:gravity="center"
+        android:text="비"
+        android:fontFamily="@font/pretendardmedium"
+        android:textColor="@android:color/black"
+        android:textSize="13dp"
+        android:paddingTop="6dp"
+        app:layout_constraintEnd_toEndOf="@+id/ll_analysis_bar_this_Week"
+        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_bar_this_Week"
+        android:visibility="gone"/>
+
+
+    <TextView
+        android:id="@+id/tv_balloon_thunder_this_week"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-4dp"
+        android:layout_marginEnd="20dp"
+        android:background="@drawable/bg_gray_balloon"
+        android:fontFamily="@font/pretendardmedium"
+        android:gravity="center"
+        android:paddingTop="6dp"
+        android:text="번개"
+        android:textColor="@android:color/black"
+        android:textSize="13dp"
+        app:layout_constraintEnd_toEndOf="@+id/ll_analysis_bar_this_Week"
+        app:layout_constraintTop_toBottomOf="@+id/ll_analysis_bar_this_Week"
+        android:visibility="gone"/>
 
     <LinearLayout
         android:id="@+id/linearLayout4"


### PR DESCRIPTION
## 개요

> 비교분석뷰 / 날씨 말풍선 구현

## 작업 사항
- [x] 감정 날씨 통계 클릭 시 나타나는 텍스트 박스 구현 
- [x] 각 날씨 bar 클릭 시 화면에 나타나도록 구현

## 참고사항 및 스크린샷
*위치 수정은 우선 나중에 해야할 것 같습니다! 가능하면 오늘 밤 이내로 할 수 있을 것 같은데 우선 메인에 머지 먼저 하고 수정하도록 하겠습니다.

https://github.com/yourweather/yourweather_android/assets/83583757/174bb67c-5e02-414e-b720-e30a1f047a6f



