### PR TITLE
[feat / #152] 비교분석뷰 / 버튼 투명도 변경

### DIFF
--- a/app/src/main/res/layout/fragment_icon_statics_monthly.xml
+++ b/app/src/main/res/layout/fragment_icon_statics_monthly.xml
@@ -53,7 +53,8 @@
             android:layout_marginLeft="11dp"
             android:layout_marginTop="1dp"
             android:background="@drawable/ic_gray_rightarrow_7_12"
-            app:layout_constraintHeight_percent="0.05" />
+            app:layout_constraintHeight_percent="0.05"
+            android:alpha="0.5"/>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_icon_statics_weekly.xml
+++ b/app/src/main/res/layout/fragment_icon_statics_weekly.xml
@@ -52,7 +52,8 @@
             android:layout_marginLeft="11dp"
             android:layout_marginTop="1dp"
             android:background="@drawable/ic_gray_rightarrow_7_12"
-            app:layout_constraintHeight_percent="0.05" />
+            app:layout_constraintHeight_percent="0.05"
+            android:alpha="0.5"/>
 
     </LinearLayout>
 


### PR DESCRIPTION
## 개요

> 비교분석뷰 / 버튼 투명도 변경

## 작업 사항
- [x]   버튼 투명도 변경 50% -> 회색으로 보여짐

## 참고사항 및 스크린샷
기능 구현 시 같이 추가할 예정이었으나, 시연 영상 찍을 때까지 시간이 촉박해서 우선 보여지는 것만 수정합니다...!
![image](https://github.com/yourweather/yourweather_android/assets/83583757/297b4007-4618-4859-b33a-79c51895987a)
![image](https://github.com/yourweather/yourweather_android/assets/83583757/dcc318ab-82e1-4e91-bc59-47b9953b01ea)
