### PR TITLE
[feat/#219] 회원가입 로직 이메일, 비밀번호, 플랫폼 값 닉네임으로 넘겨주기

### DIFF
--- a/app/src/main/java/com/umc/yourweather/data/remote/request/SignupRequest.kt
+++ b/app/src/main/java/com/umc/yourweather/data/remote/request/SignupRequest.kt
@@ -11,4 +11,11 @@ class SignupRequest(
     val nickname: String,
     @SerializedName("signup_platform")
     val platform: String,
-)
+) {
+    enum class platformList {
+        KAKAO,
+        GOOGLE,
+        NAVER,
+        YOURWEATHER,
+    }
+}

--- a/app/src/main/java/com/umc/yourweather/presentation/sign/Nickname.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/sign/Nickname.kt
@@ -32,7 +32,9 @@ class Nickname : AppCompatActivity() {
             val mIntent = Intent(this, BottomNavi::class.java)
             startActivity(mIntent)
         }
-        // SignUp2 에서 pw 값 받아오기
+        localUser()
+    }
+    private fun localUser() {
         val pw = intent.getStringExtra("password")
         val email = intent.getStringExtra("email")
         Log.d("pwDebug2", "pw value2: $pw")

--- a/app/src/main/java/com/umc/yourweather/presentation/sign/Nickname.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/sign/Nickname.kt
@@ -2,6 +2,7 @@ package com.umc.yourweather.presentation.sign
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.widget.Button
 import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
@@ -31,5 +32,11 @@ class Nickname : AppCompatActivity() {
             val mIntent = Intent(this, BottomNavi::class.java)
             startActivity(mIntent)
         }
+        // SignUp2 에서 pw 값 받아오기
+        val pw = intent.getStringExtra("password")
+        val email = intent.getStringExtra("email")
+        Log.d("pwDebug2", "pw value2: $pw")
+        Log.d("EmailDebug3", "Email value3: $email")
+        val platform = "YOURWEATHER"
     }
 }

--- a/app/src/main/java/com/umc/yourweather/presentation/sign/SignUp.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/sign/SignUp.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import android.os.CountDownTimer
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.Log
 import android.util.Patterns
 import android.view.LayoutInflater
 import android.view.View
@@ -39,9 +40,7 @@ class SignUp : AppCompatActivity() {
         }
 
         binding.btnSignupNext.setOnClickListener {
-            val mIntent = Intent(this@SignUp, SignUp2::class.java)
-            startActivity(mIntent)
-            finish()
+            userEmail()
         }
 
         binding.etSignupEmail.addTextChangedListener(createTextWatcher(::checkEmailError))
@@ -89,6 +88,15 @@ class SignUp : AppCompatActivity() {
             binding.tvSignupError.visibility = View.VISIBLE
             binding.btnSignupSendauth.isEnabled = false
         }
+    }
+
+    private fun userEmail() {
+        var email = binding.etSignupEmail.text.toString()
+        val mIntent = Intent(this@SignUp, SignUp2::class.java)
+        mIntent.putExtra("email", email)
+        startActivity(mIntent)
+        finish()
+        Log.d("EmailDebug", "Email value: $email")
     }
 
     private fun checkAuth() {

--- a/app/src/main/java/com/umc/yourweather/presentation/sign/SignUp.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/sign/SignUp.kt
@@ -95,7 +95,6 @@ class SignUp : AppCompatActivity() {
         val mIntent = Intent(this@SignUp, SignUp2::class.java)
         mIntent.putExtra("email", email)
         startActivity(mIntent)
-        finish()
         Log.d("EmailDebug", "Email value: $email")
     }
 

--- a/app/src/main/java/com/umc/yourweather/presentation/sign/SignUp2.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/sign/SignUp2.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
+import android.util.Log
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import com.umc.yourweather.R
@@ -20,8 +21,7 @@ class SignUp2 : AppCompatActivity() {
         setContentView(binding.root)
 
         binding.btnSignup2Next.setOnClickListener {
-            val mIntent = Intent(this, Nickname::class.java)
-            startActivity(mIntent)
+            getPw()
         }
         binding.btnSignup2Back.setOnClickListener {
             val mIntent = Intent(this, SignUp::class.java)
@@ -30,8 +30,24 @@ class SignUp2 : AppCompatActivity() {
         }
         binding.etSignup2Pw.addTextChangedListener(createTextWatcher(::checkPwFormat))
         binding.etSignup2Repw.addTextChangedListener(createTextWatcher(::checkRePw))
+
+
     }
 
+    private fun getPw() {
+        // SignUp1 에서 email 값 받아오기
+        val email = intent.getStringExtra("email")
+        Log.d("EmailDebug2", "Email value2: $email")
+
+        // 비밀번호 받고 넘기기
+        var pw = binding.etSignup2Pw.text.toString()
+        val mIntent = Intent(this@SignUp2, Nickname::class.java)
+        mIntent.putExtra("password", pw)
+        mIntent.putExtra("email", email)
+        startActivity(mIntent)
+        Log.d("pwDebug", "pw value2: $pw")
+
+    }
     private fun createTextWatcher(checkError: () -> Unit): TextWatcher {
         return object : TextWatcher {
             override fun afterTextChanged(p0: Editable?) {


### PR DESCRIPTION
## 개요

> 회원가입 로직 이메일, 비밀번호, 플랫폼 값 닉네임으로 넘겨주기

## 작업 사항
- [x] 회원가입 로직 이메일, 비밀번호, 플랫폼 값 닉네임으로 넘겨주기
- [x] 이메일 -> 비밀번호 입력으로 
- [x] 비밀번호, 이메일 -> 닉네임으로 
- [x] 닉네임 파일 : 이메일, 비밀번호 값 받아오기 + 자체 회원가입 함수 구현

## 참고사항 및 스크린샷
<img width="789" alt="image" src="https://github.com/yourweather/yourweather_android/assets/83583757/854e565e-f326-4b90-895c-97dca2885173">
