### PR TITLE
[feat/#258] 비교분석뷰 각 날씨별 각 월 통계 받아오는 API 붙이기

### DIFF
--- a/app/src/main/java/com/umc/yourweather/presentation/analysis/BarStaticsMonthlyFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/analysis/BarStaticsMonthlyFragment.kt
@@ -272,7 +272,7 @@ class BarStaticsMonthlyFragment : Fragment() {
         }, 1500) // 1.5초 후에 말풍선을 숨김
     }
 
-    // 이번 주 통계
+    // 이번 달 통계
     private fun barStatisticsThisMonthApi() {
         val service = RetrofitImpl.authenticatedRetrofit.create(ReportService::class.java)
         val call = service.monthlyStatistic(ago = 0) // 이번 달

--- a/app/src/main/java/com/umc/yourweather/presentation/analysis/IconStaticsMonthlyFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/analysis/IconStaticsMonthlyFragment.kt
@@ -38,17 +38,23 @@ class IconStaticsMonthlyFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        // 초기화 때 이번 달의 통계를 가져오기 위해 ago 값을 설정
+        val initialAgo = 0
+        barStatisticsThisMonthApi(initialAgo)
+        Log.d("${initialAgo}전으로", "${initialAgo}")
+
         // 버튼 클릭 시 화면 전환 함수
         setupOnClickListeners()
 
-        // 각 월별 통계 함수
-        barStatisticsThisMonthApi()
     }
 
     // 이번 달 통계
-    private fun barStatisticsThisMonthApi() {
+    private fun barStatisticsThisMonthApi(ago: Int) {
         val service = RetrofitImpl.authenticatedRetrofit.create(ReportService::class.java)
-        val call = service.monthlyStatistic(ago = 0) // 이번 달
+        val call = service.monthlyStatistic(ago = ago) // 이번 달
+
+        // 로그로 확인하기 위한 언제 달인지 변수
+        var viewMonth = currentMonth - ago
 
         call.enqueue(object : Callback<BaseResponse<StatisticResponse>> {
             override fun onResponse(
@@ -58,18 +64,22 @@ class IconStaticsMonthlyFragment : Fragment() {
                 if (response.isSuccessful) {
                     val statisticResponse = response.body()?.result // 'data'가 실제 응답 데이터를 담고 있는 필드일 경우
                     if (statisticResponse != null) {
-                        Log.d("월별 디테일 API Success", "월별 디테일 Sunny: ${statisticResponse.sunny}, Cloudy: ${statisticResponse.cloudy}, Rainy: ${statisticResponse.rainy}, Lightning: ${statisticResponse.lightning}")
+                        Log.d("${ago}개월 전 ${viewMonth}월 Success", "${viewMonth}월 디테일 Sunny: ${statisticResponse.sunny}, Cloudy: ${statisticResponse.cloudy}, Rainy: ${statisticResponse.rainy}, Lightning: ${statisticResponse.lightning}")
+                        binding.tvStaticIconDetailSunnyMonthly.text = "${statisticResponse.sunny.toInt()}%"
+                        binding.tvStaticIconDetailCloudyMonthly.text = "${statisticResponse.cloudy.toInt()}%"
+                        binding.tvStaticIconDetailRainyMonthly.text = "${statisticResponse.rainy.toInt()}%"
+                        binding.tvStaticIconDetailThunderMonthly.text = "${statisticResponse.lightning.toInt()}%"
                     } else {
-                        Log.e("월별 디테일 API Error", "Response body 비었음")
+                        Log.e("${ago}개월 전 디테일 API Error", "Response body 비었음")
                     }
                 } else {
                     val errorBody = response.errorBody()?.string()
-                    Log.e("월별 디테일 API Error", "Response Code: ${response.code()}, Error Body: $errorBody")
+                    Log.e("${ago}개월 전 디테일 API Error", "Response Code: ${response.code()}, Error Body: $errorBody")
                 }
             }
 
             override fun onFailure(call: Call<BaseResponse<StatisticResponse>>, t: Throwable) {
-                Log.e("월별 디테일 bar API Failure", "Error: ${t.message}", t)
+                Log.e("${ago}개월 전 디테일 bar API Failure", "Error: ${t.message}", t)
             }
         })
     }
@@ -120,6 +130,9 @@ class IconStaticsMonthlyFragment : Fragment() {
                 updateMonth--
                 binding.tvUnwrittenTitleMonthly.text = updateMonth.toString() + "월"
                 binding.btnStaticsRightDateMonthly.alpha = 1f
+                // api로 보낼 값지정
+                val ago = currentMonth - updateMonth
+                barStatisticsThisMonthApi(ago)
             }
             if (updateMonth == 1) {
                 binding.btnStaticsLeftDateMonthly.alpha = 0.5f
@@ -133,6 +146,9 @@ class IconStaticsMonthlyFragment : Fragment() {
                 updateMonth++
                 binding.tvUnwrittenTitleMonthly.text = updateMonth.toString() + "월"
                 binding.btnStaticsRightDateMonthly.alpha = 1f
+                // api로 보낼 값지정
+                val ago = currentMonth - updateMonth
+                barStatisticsThisMonthApi(ago)
             }
             if (updateMonth == currentMonth) {
                 binding.btnStaticsRightDateMonthly.alpha = 0.5f

--- a/app/src/main/java/com/umc/yourweather/presentation/analysis/IconStaticsMonthlyFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/analysis/IconStaticsMonthlyFragment.kt
@@ -41,11 +41,10 @@ class IconStaticsMonthlyFragment : Fragment() {
         // 초기화 때 이번 달의 통계를 가져오기 위해 ago 값을 설정
         val initialAgo = 0
         barStatisticsThisMonthApi(initialAgo)
-        Log.d("${initialAgo}전으로", "${initialAgo}")
+        Log.d("${initialAgo}전으로", "$initialAgo")
 
         // 버튼 클릭 시 화면 전환 함수
         setupOnClickListeners()
-
     }
 
     // 이번 달 통계

--- a/app/src/main/java/com/umc/yourweather/presentation/analysis/IconStaticsWeeklyFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/analysis/IconStaticsWeeklyFragment.kt
@@ -1,12 +1,20 @@
 package com.umc.yourweather.presentation.analysis
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.umc.yourweather.R
+import com.umc.yourweather.data.remote.response.BaseResponse
+import com.umc.yourweather.data.remote.response.StatisticResponse
+import com.umc.yourweather.data.service.ReportService
 import com.umc.yourweather.databinding.FragmentIconStaticsWeeklyBinding
+import com.umc.yourweather.di.RetrofitImpl
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
 
 class IconStaticsWeeklyFragment : Fragment() {
     private var _binding: FragmentIconStaticsWeeklyBinding? = null
@@ -27,6 +35,12 @@ class IconStaticsWeeklyFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        // 초기화 때 이번 달의 통계를 가져오기 위해 ago 값을 설정
+        val initialAgo = 0
+        barStatisticsThisWeekApi(initialAgo)
+        Log.d("${initialAgo}전으로", "${initialAgo}")
+
         setupOnClickListeners()
     }
 
@@ -92,12 +106,43 @@ class IconStaticsWeeklyFragment : Fragment() {
                 binding.btnStaticsLeftDateWeekly.alpha = 1f
             }
         }
+    }
+    private fun barStatisticsThisWeekApi(ago: Int) {
+        val service = RetrofitImpl.authenticatedRetrofit.create(ReportService::class.java)
+        val call = service.weeklyStatistic(ago = ago) // 이번 달
 
+
+        call.enqueue(object : Callback<BaseResponse<StatisticResponse>> {
+            override fun onResponse(
+                call: Call<BaseResponse<StatisticResponse>>,
+                response: Response<BaseResponse<StatisticResponse>>,
+            ) {
+                if (response.isSuccessful) {
+                    val statisticResponse = response.body()?.result // 'data'가 실제 응답 데이터를 담고 있는 필드일 경우
+                    if (statisticResponse != null) {
+                        Log.d("${ago}주 전 디테일 Success", "${ago}주 전 디테일 Sunny: ${statisticResponse.sunny}, Cloudy: ${statisticResponse.cloudy}, Rainy: ${statisticResponse.rainy}, Lightning: ${statisticResponse.lightning}")
+                        binding.tvStaticIconDetailSunnyWeekly.text = "${statisticResponse.sunny.toInt()}%"
+                        binding.tvStaticIconDetailCloudyWeekly.text = "${statisticResponse.cloudy.toInt()}%"
+                        binding.tvStaticIconDetailRainyWeekly.text = "${statisticResponse.rainy.toInt()}%"
+                        binding.tvStaticIconDetailThunderWeekly.text = "${statisticResponse.lightning.toInt()}%"
+                    } else {
+                        Log.e("${ago}주 전 디테일 API Error", "Response body 비었음")
+                    }
+                } else {
+                    val errorBody = response.errorBody()?.string()
+                    Log.e("${ago}주 전 디테일 API Error", "Response Code: ${response.code()}, Error Body: $errorBody")
+                }
+            }
+
+            override fun onFailure(call: Call<BaseResponse<StatisticResponse>>, t: Throwable) {
+                Log.e("${ago}주 전 디테일 bar API Failure", "Error: ${t.message}", t)
+            }
+        })
     }
     private fun updateTitleAndFetchStatistics(weekAgo: Int) {
         val ago = weekAgo
         binding.tvUnwrittenTitleWeekly.text = "${ago}주 전"
-        // barStatisticsThisWeekApi(ago)
+        barStatisticsThisWeekApi(ago)
 
         if (ago == 0) {
             binding.tvUnwrittenTitleWeekly.text = "이번 주"

--- a/app/src/main/java/com/umc/yourweather/presentation/analysis/IconStaticsWeeklyFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/analysis/IconStaticsWeeklyFragment.kt
@@ -62,6 +62,46 @@ class IconStaticsWeeklyFragment : Fragment() {
         binding.btnStaticsRightDetail4Weekly.setOnClickListener {
             replaceFragment(WrittenDetailListFragmentSunWeekly())
         }
+        // 현재 주
+        binding.tvUnwrittenTitleWeekly.text = "이번 주"
+
+        // 오른쪽 버튼 투명도 0.5로 고정
+        binding.btnStaticsRightDateWeekly.alpha = 0.5f
+
+        var updateWeek = 0 // 현재 주
+        // 과거 주로 이동
+        binding.btnStaticsLeftDateWeekly.setOnClickListener {
+            if (updateWeek < 4) {
+                updateWeek++
+                updateTitleAndFetchStatistics(updateWeek)
+            }
+            if (updateWeek == 4) {
+                binding.btnStaticsLeftDateWeekly.alpha = 0.5f
+                binding.btnStaticsRightDateWeekly.alpha = 1f
+            }
+        }
+
+        // 현재 주로 오기
+        binding.btnStaticsRightDateWeekly.setOnClickListener {
+            if (updateWeek > 0) {
+                updateWeek--
+                updateTitleAndFetchStatistics(updateWeek)
+            }
+            if (updateWeek == 0) {
+                binding.btnStaticsRightDateWeekly.alpha = 0.5f
+                binding.btnStaticsLeftDateWeekly.alpha = 1f
+            }
+        }
+
+    }
+    private fun updateTitleAndFetchStatistics(weekAgo: Int) {
+        val ago = weekAgo
+        binding.tvUnwrittenTitleWeekly.text = "${ago}주 전"
+        // barStatisticsThisWeekApi(ago)
+
+        if (ago == 0) {
+            binding.tvUnwrittenTitleWeekly.text = "이번 주"
+        }
     }
 
     private fun replaceFragment(fragment: Fragment) {

--- a/app/src/main/java/com/umc/yourweather/presentation/analysis/IconStaticsWeeklyFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/analysis/IconStaticsWeeklyFragment.kt
@@ -39,7 +39,7 @@ class IconStaticsWeeklyFragment : Fragment() {
         // 초기화 때 이번 달의 통계를 가져오기 위해 ago 값을 설정
         val initialAgo = 0
         barStatisticsThisWeekApi(initialAgo)
-        Log.d("${initialAgo}전으로", "${initialAgo}")
+        Log.d("${initialAgo}전으로", "$initialAgo")
 
         setupOnClickListeners()
     }
@@ -110,7 +110,6 @@ class IconStaticsWeeklyFragment : Fragment() {
     private fun barStatisticsThisWeekApi(ago: Int) {
         val service = RetrofitImpl.authenticatedRetrofit.create(ReportService::class.java)
         val call = service.weeklyStatistic(ago = ago) // 이번 달
-
 
         call.enqueue(object : Callback<BaseResponse<StatisticResponse>> {
             override fun onResponse(


### PR DESCRIPTION
## 개요

> 비교분석뷰 각 날씨별 각 월 통계 받아오는 API 붙이기

## 작업 사항
#258 
- [x] 비교분석뷰 각 날씨별 각 월 통계 받아오는 API 붙이기 - 월간
- [x]  비교분석뷰 각 날씨별 각 월 통계 받아오는 API 붙이기 - 주간

## 참고사항 및 스크린샷
![image](https://github.com/yourweather/yourweather_android/assets/83583757/bc3d5ed0-e119-4312-9d02-66cefc346605)
![image](https://github.com/yourweather/yourweather_android/assets/83583757/732d8b8d-d4a3-4b07-a9bf-8dbdb4f9feff)
![image](https://github.com/yourweather/yourweather_android/assets/83583757/b73e14c1-08ba-4031-bb72-071c406b5382)
