### PR TITLE
[feat#/325]첫화면 홈화면 or 입력창

### DIFF
--- a/app/src/main/java/com/umc/yourweather/presentation/BottomNavi.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/BottomNavi.kt
@@ -1,16 +1,34 @@
 
 package com.umc.yourweather.presentation
 
+import android.os.Build
 import android.os.Bundle
+import android.util.Log
 import android.widget.FrameLayout
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.umc.yourweather.R
-import com.umc.yourweather.presentation.mypage.MyPageFragment
+import com.umc.yourweather.data.remote.response.BaseResponse
+import com.umc.yourweather.data.remote.response.MonthResponse
+import com.umc.yourweather.data.remote.response.MonthWeatherResponse
+import com.umc.yourweather.data.service.WeatherService
+import com.umc.yourweather.di.RetrofitImpl
 import com.umc.yourweather.presentation.analysis.AnalysisFragment
 import com.umc.yourweather.presentation.calendar.CalendarTotalViewFragment
+import com.umc.yourweather.presentation.mypage.MyPageFragment
+import com.umc.yourweather.presentation.weatherinput.HomeFragment
 import com.umc.yourweather.presentation.weatherinput.InitialNoWeatherFragment
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 class BottomNavi : AppCompatActivity() {
     private val fl: FrameLayout by lazy {
@@ -21,21 +39,52 @@ class BottomNavi : AppCompatActivity() {
         findViewById(R.id.bnv_main)
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_bnv)
 
-        // 최초 한 번만 트랜잭션을 시작
+        // false 반환시 입력값 없음 -> 오류났을 때 무조건 false반환하게
+        // true 반환시 입렧값 있음
+
         if (savedInstanceState == null) {
-            supportFragmentManager.beginTransaction()
-                .replace(fl.id, InitialNoWeatherFragment())
-                .commit()
+            CoroutineScope(Dispatchers.Main).launch {
+                val result = isTodayRecordExist()
+                if (result) {
+                    Log.d("코루틴 반환값 확인", "$result")
+                    Log.d("코루틴 시작 메인함수 ", "결과옴")
+                    Log.d("코루틴 시작 메인함수", "프래그먼트 시작")
+                    supportFragmentManager.beginTransaction()
+                        .replace(fl.id, HomeFragment())
+                        .commit()
+                } else {
+                    Log.d("코루틴 시작 메인함수 ", "결과옴")
+                    Log.d("코루틴 시작 메인함수", "프래그먼트")
+                    supportFragmentManager.beginTransaction()
+                        .replace(fl.id, InitialNoWeatherFragment())
+                        .commit()
+                }
+            }
         }
 
         bn.setOnItemSelectedListener {
             when (it.itemId) {
-                R.id.bnv_home -> replaceFragment(InitialNoWeatherFragment())
-//                R.id.bnv_calender -> replaceFragment(BnvCalender())
+                R.id.bnv_home -> {
+                    CoroutineScope(Dispatchers.Main).launch {
+                        val result = isTodayRecordExist()
+                        Log.d("코루틴 반환값 확인", "$result")
+                        Log.d("코루틴 시작 메인함수 ", "결과옴")
+                        Log.d("코루틴 시작 메인함수", "프래그먼트 시작")
+                        if (result) {
+                            replaceFragment(HomeFragment()) // isExistMissedInput가 true일 때 띄울 프래그먼트를 넣으세요.
+                        } else {
+                            Log.d("코루틴 시작 메인함수 ", "결과옴")
+                            Log.d("코루틴 시작 메인함수", "프래그먼트")
+                            replaceFragment(InitialNoWeatherFragment())
+                        }
+                    }
+                }
+
                 R.id.bnv_calender -> replaceFragment(CalendarTotalViewFragment())
                 R.id.bnv_report -> replaceFragment(AnalysisFragment())
                 else -> replaceFragment(MyPageFragment())
@@ -49,5 +98,60 @@ class BottomNavi : AppCompatActivity() {
         supportFragmentManager.beginTransaction()
             .replace(fl.id, fragment)
             .commit()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private suspend fun isTodayRecordExist(): Boolean {
+        val service = RetrofitImpl.authenticatedRetrofit.create(WeatherService::class.java)
+        var weatherData: List<MonthWeatherResponse> = emptyList()
+        val todayDate = LocalDate.now()
+        val month = todayDate.monthValue
+        val year = todayDate.year
+        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        val formattedTodayDate = todayDate.format(formatter)
+
+        return suspendCancellableCoroutine { continuation ->
+            val call = service.getMonthData(year = year, month = month)
+            call.enqueue(object : Callback<BaseResponse<MonthResponse>> {
+                override fun onResponse(
+                    call: Call<BaseResponse<MonthResponse>>,
+                    response: Response<BaseResponse<MonthResponse>>,
+                ) {
+                    val weatherResponse = response.body()
+                    val code = weatherResponse?.code
+                    if (response.isSuccessful) {
+                        if (code == 200) {
+                            val weatherData = weatherResponse?.result?.weatherList ?: emptyList()
+                            Log.d(
+                                "로그인, 미입력조회..",
+                                "thisDate : ${weatherData.any { it.date == formattedTodayDate }}",
+                            )
+                            Log.d("코루틴 시작 요청함수 ", "요청시작")
+                            Log.d("코루틴 시작 요청함수", "결과옴")
+                            val isTodayRecordExist = weatherData.any { it.date == formattedTodayDate }
+
+                            Log.d(
+                                "코루틴 시작 요청함수",
+                                "$isTodayRecordExist $formattedTodayDate $weatherData}",
+
+                            )
+                            continuation.resume(isTodayRecordExist, null)
+                        } else {
+                            Log.d(
+                                "Calendar",
+                                "onResponse 에러: " + weatherResponse?.message.toString(),
+                            )
+                        }
+                    } else {
+                        Log.d("Calendar", "onFailure 에러: " + weatherResponse?.message.toString())
+                    }
+                }
+
+                override fun onFailure(call: Call<BaseResponse<MonthResponse>>, t: Throwable) {
+                    Log.d("Calendar", "onFailure 에러: " + t.message.toString())
+                    continuation.resume(false, null)
+                }
+            })
+        }
     }
 }

--- a/app/src/main/java/com/umc/yourweather/presentation/calendar/CalendarTotalViewFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/calendar/CalendarTotalViewFragment.kt
@@ -15,7 +15,6 @@ import androidx.viewpager2.widget.ViewPager2
 import com.umc.yourweather.R
 import com.umc.yourweather.data.entity.CalendarDateInfo
 import com.umc.yourweather.databinding.FragmentCalendarTotalViewBinding
-import com.umc.yourweather.di.App
 import com.umc.yourweather.presentation.adapter.CalendarMonthAdapter
 import com.umc.yourweather.presentation.adapter.CalendarSelectAdapter
 import com.umc.yourweather.util.CalendarUtils.Companion.dpToPx
@@ -41,9 +40,7 @@ class CalendarTotalViewFragment : Fragment() {
     @RequiresApi(Build.VERSION_CODES.O)
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-//        TestApi()
-        Log.d("캘린더.. 저장했던 리프래스 확인", "${App.token_prefs.refreshToken}")
-        Log.d("캘린더... 저장했던 액세스확인", "${App.token_prefs.accessToken}")
+
         monthrAdapter = CalendarMonthAdapter(requireActivity())
 
         binding.vp2Calendar.adapter = monthrAdapter

--- a/app/src/main/java/com/umc/yourweather/presentation/sign/SignIn.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/sign/SignIn.kt
@@ -28,10 +28,8 @@ import com.navercorp.nid.profile.data.NidProfileResponse
 import com.umc.yourweather.BuildConfig
 import com.umc.yourweather.data.remote.request.LoginRequest
 import com.umc.yourweather.data.remote.response.BaseResponse
-import com.umc.yourweather.data.remote.response.MissedInputResponse
 import com.umc.yourweather.data.remote.response.TokenResponse
 import com.umc.yourweather.data.service.LoginService
-import com.umc.yourweather.data.service.WeatherService
 import com.umc.yourweather.databinding.ActivitySignInBinding
 import com.umc.yourweather.di.App
 import com.umc.yourweather.di.RetrofitImpl
@@ -44,15 +42,12 @@ import com.umc.yourweather.util.SignUtils.Companion.customSingInPopupWindow
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
-import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
 class SignIn : AppCompatActivity() {
     lateinit var binding: ActivitySignInBinding
     lateinit var resultLauncherGoogle: ActivityResultLauncher<Intent>
     var userEmail: String? = null
     var userPw: String? = null
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivitySignInBinding.inflate(layoutInflater)
@@ -131,7 +126,7 @@ class SignIn : AppCompatActivity() {
                         App.token_prefs.accessToken = response.body()!!.result?.accessToken
                         App.token_prefs.refreshToken = response.body()!!.result?.refreshToken
                         // startActivity(mIntent)
-                        getMissedInput()
+                        moveToHome()
                     } else {
                         Log.d(
                             "SignInDebug",
@@ -173,7 +168,7 @@ class SignIn : AppCompatActivity() {
                         App.token_prefs.accessToken = response.body()!!.result?.accessToken
                         App.token_prefs.refreshToken = response.body()!!.result?.refreshToken
 
-                        getMissedInput()
+                        moveToHome()
                         // startActivity(mIntent)
                     } else {
                         Log.d(
@@ -304,55 +299,8 @@ class SignIn : AppCompatActivity() {
             Log.w("failed", "signInResult:failed code=" + e.statusCode)
         }
     }
-
-    // 미입력 조회, 분기에 따라 홈화면/이니셜뷰로 가야함..
-    // 화면 전환 시에만 호출해야함.
-//    @GET("/api/v1/weather/no-inputs")
-//    fun getMissedInput(): Call<BaseResponse<MissedInputResponse>>
-
-    @RequiresApi(Build.VERSION_CODES.O)
-    fun getMissedInput() {
-        val service = RetrofitImpl.authenticatedRetrofit.create(WeatherService::class.java)
-        var missedDateList: List<String>? = emptyList()
-        val todayDate = LocalDate.now()
-        val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
-        val formattedDate = todayDate.format(formatter)
-
-        service.getMissedInput().enqueue(object : Callback<BaseResponse<MissedInputResponse>> {
-            override fun onResponse(
-                call: Call<BaseResponse<MissedInputResponse>>,
-                response: Response<BaseResponse<MissedInputResponse>>,
-            ) {
-                if (response.isSuccessful) {
-                    val responseBody = response.body()
-                    val code = responseBody?.code
-                    if (code == 200) {
-                        missedDateList = responseBody.result?.localDates
-                        if (missedDateList?.contains(formattedDate) == true) { // 미입력이 있다.
-                            val mIntent = Intent(this@SignIn, BottomNavi::class.java)
-                            mIntent.putExtra("isExistMissedInput", true)
-                            startActivity(mIntent)
-                        } else {
-                            val mIntent = Intent(this@SignIn, BottomNavi::class.java)
-                            startActivity(mIntent)
-                        }
-
-                        Log.d("MissInputDebug", "미입력 조회 성공")
-                    } else {
-                        // 실패하면 그냥 이동.
-                        Log.d("MissInputDebug", "미입력 조회 실패")
-                        val mIntent = Intent(this@SignIn, BottomNavi::class.java)
-                        startActivity(mIntent)
-                    }
-                }
-            }
-
-            override fun onFailure(call: Call<BaseResponse<MissedInputResponse>>, t: Throwable) {
-                // 네트워크 에러 처리
-                Log.d("MissInputDebug", "네트워크 오류: " + t.message.toString())
-                val mIntent = Intent(this@SignIn, BottomNavi::class.java)
-                startActivity(mIntent)
-            }
-        })
+    private fun moveToHome() {
+        val mIntent = Intent(this@SignIn, BottomNavi::class.java)
+        startActivity(mIntent)
     }
 }


### PR DESCRIPTION
## 개요

> 오늘 입력한 값있는지에 따라 첫화면 홈화면 or 입력창으로 이동. 
월날씨 조회 api를 통해 구현하였습니다. null 값일 시 입력창 이동.

## 작업 사항
- [x]  월 날씨 조회 api 바텀네비에 붙임
- [x] 코루틴 적용해서 조회 api 요청 옴 -> 조회 api 응답 옴 -> 프래그먼트 불러옴 순서로 구현(리프래시 토큰 갱신의 비동기식 문제 때문에 이렇게 했습니다)


## 참고사항 및 스크린샷
