### PR TITLE
[remove/#393] 상세보기 일기가 없는 경우

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -128,11 +128,11 @@
             android:name=".presentation.calendardetailview.CalendarDetailViewEmpty"
             android:exported="false" />
         <activity
-            android:name=".presentation.calendardetailview.CalendarDetailviewModify1"
+            android:name=".presentation.calendardetailview.CalendarWeatherDetail"
             android:exported="true"
             android:windowSoftInputMode="adjustPan" />
         <activity
-            android:name=".presentation.calendardetailview.CalendarDetailviewModify2"
+            android:name=".presentation.calendardetailview.CalendarPlusWeather"
             android:exported="true"
             android:windowSoftInputMode="adjustPan" />
         <activity

--- a/app/src/main/java/com/umc/yourweather/presentation/adapter/CalendarDetailMemoListAdapter.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/adapter/CalendarDetailMemoListAdapter.kt
@@ -1,17 +1,12 @@
 package com.umc.yourweather.presentation.adapter
 
 import android.content.Context
-import android.content.Intent
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.RecyclerView
 import com.umc.yourweather.data.remote.response.MemoDailyResponse
 import com.umc.yourweather.databinding.ItemCalendarDetailMemolistBinding
-import com.umc.yourweather.presentation.calendardetailview.CalendarDetailviewModify1
-import com.umc.yourweather.util.CalendarUtils.Companion.dpToPx
 import com.umc.yourweather.util.ResourceUtils.Companion.setWeatherIc
 
 class CalendarDetailMemoListAdapter(private val memoList: List<MemoDailyResponse.MemoItemResponse>, private val context: Context) :

--- a/app/src/main/java/com/umc/yourweather/presentation/adapter/UnwrittenRVAdapter.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/adapter/UnwrittenRVAdapter.kt
@@ -41,8 +41,6 @@ class UnwrittenRVAdapter(private val dataList: List<ItemUnwritten>, private val 
             val localDate = localDates[position] // 해당 아이템의 localDate 가져오기
 
             binding.linearLayout3.setOnClickListener {
-                val intent = Intent(context, CalendarPlusWeather::class.java)
-                context.startActivity(intent)
                 val dIntent = Intent(context, CalendarPlusWeather::class.java)
                 dIntent.putExtra("unWrittenDate", localDate)
                 context.startActivity(dIntent)

--- a/app/src/main/java/com/umc/yourweather/presentation/adapter/UnwrittenRVAdapter.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/adapter/UnwrittenRVAdapter.kt
@@ -8,8 +8,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.umc.yourweather.data.entity.ItemUnwritten
 import com.umc.yourweather.databinding.ItemUnwrittenDetailBinding
-import com.umc.yourweather.presentation.calendar.CalendarTotalViewFragment
-import com.umc.yourweather.presentation.calendardetailview.CalendarDetailviewModify2
+import com.umc.yourweather.presentation.calendardetailview.CalendarPlusWeather
 
 class UnwrittenRVAdapter(private val dataList: List<ItemUnwritten>, private val localDates: List<String>, private val context: Context) :
     RecyclerView.Adapter<UnwrittenRVAdapter.MyViewHolder>() {
@@ -42,9 +41,9 @@ class UnwrittenRVAdapter(private val dataList: List<ItemUnwritten>, private val 
             val localDate = localDates[position] // 해당 아이템의 localDate 가져오기
 
             binding.linearLayout3.setOnClickListener {
-                val intent = Intent(context, CalendarDetailviewModify2::class.java)
+                val intent = Intent(context, CalendarPlusWeather::class.java)
                 context.startActivity(intent)
-                val dIntent = Intent(context, CalendarDetailviewModify2::class.java)
+                val dIntent = Intent(context, CalendarPlusWeather::class.java)
                 dIntent.putExtra("unWrittenDate", localDate)
                 context.startActivity(dIntent)
                 Log.d("localDate","$localDate")

--- a/app/src/main/java/com/umc/yourweather/presentation/adapter/WrittenRVAdapter.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/adapter/WrittenRVAdapter.kt
@@ -8,7 +8,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.umc.yourweather.data.entity.ItemWritten
 import com.umc.yourweather.databinding.ItemWrittenDetailSunBinding
-import com.umc.yourweather.presentation.calendardetailview.CalendarDetailviewModify1
+import com.umc.yourweather.presentation.calendardetailview.CalendarWeatherDetail
 class WrittenRVAdapter(private val dataList: List<ItemWritten>, private val context: Context, private val memoIds: List<Int>) :
     RecyclerView.Adapter<WrittenRVAdapter.MyViewHolder>() {
 
@@ -38,7 +38,7 @@ class WrittenRVAdapter(private val dataList: List<ItemWritten>, private val cont
             binding.tvStaticIconDetailSunny.text = "${data.formattedDateTime}"
 
             binding.linearLayout3.setOnClickListener {
-                val intent = Intent(context, CalendarDetailviewModify1::class.java)
+                val intent = Intent(context, CalendarWeatherDetail::class.java)
                 intent.putExtra("dateTime", data.dateTime) // 전달할 데이터 추가
                 intent.putExtra("memoIdW", memoId) // 수정된 코드: 메모 아이디 대신 memoId 전달
                 context.startActivity(intent)

--- a/app/src/main/java/com/umc/yourweather/presentation/calendar/CalendarDetail.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/calendar/CalendarDetail.kt
@@ -1,7 +1,6 @@
 package com.umc.yourweather.presentation.calendar
 
 import android.content.Intent
-import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
@@ -9,12 +8,6 @@ import android.view.View
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.github.mikephil.charting.components.XAxis
-import com.github.mikephil.charting.data.Entry
-import com.github.mikephil.charting.data.LineData
-import com.github.mikephil.charting.data.LineDataSet
-import com.github.mikephil.charting.formatter.DefaultValueFormatter
-import com.umc.yourweather.R
 import com.umc.yourweather.data.remote.response.BaseResponse
 import com.umc.yourweather.data.remote.response.MemoDailyResponse
 import com.umc.yourweather.data.service.MemoService
@@ -23,7 +16,7 @@ import com.umc.yourweather.di.RetrofitImpl
 import com.umc.yourweather.di.UserSharedPreferences
 import com.umc.yourweather.presentation.adapter.CalendarDetailMemoContentAdapter
 import com.umc.yourweather.presentation.adapter.CalendarDetailMemoListAdapter
-import com.umc.yourweather.presentation.calendardetailview.CalendarDetailviewModify1
+import com.umc.yourweather.presentation.calendardetailview.CalendarWeatherDetail
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -171,7 +164,7 @@ class CalendarDetail : AppCompatActivity() {
         // 클릭하면 수정페이지로 넘어감
         memoListAdapter.setOnItemClickListener(object : CalendarDetailMemoListAdapter.OnItemClickListener {
             override fun onItemClick(view: View, position: Int, memoId: Int) {
-                val mIntent = Intent(this@CalendarDetail, CalendarDetailviewModify1::class.java)
+                val mIntent = Intent(this@CalendarDetail, CalendarWeatherDetail::class.java)
                 mIntent.putExtra("memoId", memoId)
                 startActivity(mIntent)
             }

--- a/app/src/main/java/com/umc/yourweather/presentation/calendardetailview/CalendarDetailViewEmpty.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/calendardetailview/CalendarDetailViewEmpty.kt
@@ -14,7 +14,7 @@ class CalendarDetailViewEmpty : AppCompatActivity() {
         val btnModify: Button = findViewById(R.id.button2)
 
         btnModify.setOnClickListener {
-            val intent = Intent(this@CalendarDetailViewEmpty, CalendarDetailviewModify1::class.java)
+            val intent = Intent(this@CalendarDetailViewEmpty, CalendarWeatherDetail::class.java)
             startActivity(intent)
         }
     }

--- a/app/src/main/java/com/umc/yourweather/presentation/calendardetailview/CalendarDetailviewModify1.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/calendardetailview/CalendarDetailviewModify1.kt
@@ -119,7 +119,6 @@ class CalendarDetailviewModify1 : AppCompatActivity() {
     }
 
     // 날씨 상태 애니메이션
-    // 날씨 상태 애니메이션
     private fun animateAndHandleButtonClick(Status: Status) {
         val buttonAnimation: Animation = AnimationUtils.loadAnimation(this, R.anim.btn_weather_scale)
         when (Status) {

--- a/app/src/main/java/com/umc/yourweather/presentation/calendardetailview/CalendarDetailviewTimepicker.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/calendardetailview/CalendarDetailviewTimepicker.kt
@@ -1,6 +1,5 @@
 package com.umc.yourweather.presentation.calendardetailview
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
@@ -61,7 +60,7 @@ class CalendarDetailviewTimepicker : Fragment() {
             val timeText = formattedTime
 
 
-            (activity as? CalendarDetailviewModify2)?.updateTimeText(timeText)
+            (activity as? CalendarPlusWeather)?.updateTimeText(timeText)
 
             parentFragmentManager.popBackStack()
         }

--- a/app/src/main/java/com/umc/yourweather/presentation/calendardetailview/CalendarModifyWeatherFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/calendardetailview/CalendarModifyWeatherFragment.kt
@@ -1,0 +1,60 @@
+package com.umc.yourweather.presentation.calendardetailview
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.umc.yourweather.R
+
+// TODO: Rename parameter arguments, choose names that match
+// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+private const val ARG_PARAM1 = "param1"
+private const val ARG_PARAM2 = "param2"
+
+/**
+ * A simple [Fragment] subclass.
+ * Use the [CalendarModifyWeatherFragment.newInstance] factory method to
+ * create an instance of this fragment.
+ */
+class CalendarModifyWeatherFragment : Fragment() {
+    // TODO: Rename and change types of parameters
+    private var param1: String? = null
+    private var param2: String? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            param1 = it.getString(ARG_PARAM1)
+            param2 = it.getString(ARG_PARAM2)
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_calendar_modify_weather, container, false)
+    }
+
+    companion object {
+        /**
+         * Use this factory method to create a new instance of
+         * this fragment using the provided parameters.
+         *
+         * @param param1 Parameter 1.
+         * @param param2 Parameter 2.
+         * @return A new instance of fragment CalendarModifyWeatherFragment.
+         */
+        // TODO: Rename and change types and number of parameters
+        @JvmStatic
+        fun newInstance(param1: String, param2: String) =
+            CalendarModifyWeatherFragment().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_PARAM1, param1)
+                    putString(ARG_PARAM2, param2)
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/umc/yourweather/presentation/calendardetailview/CalendarPlusWeather.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/calendardetailview/CalendarPlusWeather.kt
@@ -1,26 +1,21 @@
 package com.umc.yourweather.presentation.calendardetailview
 
-import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import android.widget.Button
 import android.widget.SeekBar
-import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatEditText
 import androidx.core.content.ContextCompat
-import com.mmk.timeintervalpicker.TimeIntervalPicker
 import com.umc.yourweather.R
 import com.umc.yourweather.data.enums.Status
 import com.umc.yourweather.data.remote.request.MemoRequest
-import com.umc.yourweather.data.remote.request.MemoUpdateRequest
 import com.umc.yourweather.data.remote.response.BaseResponse
 import com.umc.yourweather.data.remote.response.MemoResponse
-import com.umc.yourweather.data.remote.response.MemoUpdateResponse
 import com.umc.yourweather.data.service.MemoService
-import com.umc.yourweather.databinding.ActivityCalendarDetailviewModify2Binding
+import com.umc.yourweather.databinding.ActivityCalendarPlusWeatherBinding
 import com.umc.yourweather.di.RetrofitImpl
 import com.umc.yourweather.di.UserSharedPreferences
 import kotlinx.coroutines.Dispatchers
@@ -33,15 +28,15 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 
-class CalendarDetailviewModify2 : AppCompatActivity() {
-    private lateinit var binding: ActivityCalendarDetailviewModify2Binding
+class CalendarPlusWeather : AppCompatActivity() {
+    private lateinit var binding: ActivityCalendarPlusWeatherBinding
     private lateinit var editText: AppCompatEditText
     private var isSeekBarAdjusted = false // 변수 선언
     private var selectedStatus: Status? = null // 기본값으로 SUNNY 설정
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityCalendarDetailviewModify2Binding.inflate(layoutInflater)
+        binding = ActivityCalendarPlusWeatherBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
         editText = binding.editText as AppCompatEditText
@@ -62,7 +57,7 @@ class CalendarDetailviewModify2 : AppCompatActivity() {
         binding.flCalendarDetailviewBack.setOnClickListener {
             activityFinish()
         }
-        val userNickname = UserSharedPreferences.getUserNickname(this@CalendarDetailviewModify2)
+        val userNickname = UserSharedPreferences.getUserNickname(this@CalendarPlusWeather)
 
         binding.tvDetailviewModify2Title1.text = "$userNickname 님의 감정 상태"
         binding.tvDetailviewModify2Title2.text = "$userNickname 님의 감정 온도"

--- a/app/src/main/java/com/umc/yourweather/presentation/calendardetailview/CalendarPlusWeather.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/calendardetailview/CalendarPlusWeather.kt
@@ -214,8 +214,6 @@ class CalendarPlusWeather : AppCompatActivity() {
     }
 
     private fun activityFinish() {
-//        val intent = Intent(this, CalendarDetailView3::class.java)
-//        startActivity(intent)
-//        finish()
+        finish()
     }
 }

--- a/app/src/main/java/com/umc/yourweather/presentation/calendardetailview/CalendarWeatherDetail.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/calendardetailview/CalendarWeatherDetail.kt
@@ -12,7 +12,7 @@ import com.umc.yourweather.data.remote.response.BaseResponse
 import com.umc.yourweather.data.remote.response.MemoResponse
 import com.umc.yourweather.data.remote.response.MemoUpdateResponse
 import com.umc.yourweather.data.service.MemoService
-import com.umc.yourweather.databinding.ActivityCalendarDetailviewModify1Binding
+import com.umc.yourweather.databinding.ActivityCalendarWeatherDetailBinding
 import com.umc.yourweather.di.RetrofitImpl
 import com.umc.yourweather.di.UserSharedPreferences
 import retrofit2.Call
@@ -21,12 +21,12 @@ import retrofit2.Response
 import java.text.SimpleDateFormat
 import java.util.Locale
 
-class CalendarDetailviewModify1 : AppCompatActivity() {
-    private lateinit var binding: ActivityCalendarDetailviewModify1Binding
+class CalendarWeatherDetail : AppCompatActivity() {
+    private lateinit var binding: ActivityCalendarWeatherDetailBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityCalendarDetailviewModify1Binding.inflate(layoutInflater)
+        binding = ActivityCalendarWeatherDetailBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
         // Intent에서 캘린더에서 접근 시 memoId 추ㅛㅕㅕ갸출

--- a/app/src/main/res/layout/activity_calendar_detail.xml
+++ b/app/src/main/res/layout/activity_calendar_detail.xml
@@ -123,15 +123,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/tv_calendar_detail_no_total_data">
 
-        <TextView
-            android:id="@+id/tv_calendar_detail_inputnow"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:fontFamily="@font/pretendardsemibold"
-            android:gravity="center"
-            android:text="지금 입력하기"
-            android:textColor="@color/sorange"
-            android:textSize="11dp" />
+<!--        <TextView-->
+<!--            android:id="@+id/tv_calendar_detail_inputnow"-->
+<!--            android:layout_width="wrap_content"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:fontFamily="@font/pretendardsemibold"-->
+<!--            android:gravity="center"-->
+<!--            android:text="지금 입력하기"-->
+<!--            android:textColor="@color/sorange"-->
+<!--            android:textSize="11dp" />-->
 
         <View
             android:id="@+id/divider_calendar_detail_01"

--- a/app/src/main/res/layout/activity_calendar_plus_weather.xml
+++ b/app/src/main/res/layout/activity_calendar_plus_weather.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".presentation.calendardetailview.CalendarDetailviewModify2">
+    tools:context=".presentation.calendardetailview.CalendarPlusWeather">
     <FrameLayout
         android:id="@+id/fragment_container"
         android:layout_width="0dp"

--- a/app/src/main/res/layout/activity_calendar_weather_detail.xml
+++ b/app/src/main/res/layout/activity_calendar_weather_detail.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".presentation.calendardetailview.CalendarDetailviewModify2">
+    tools:context=".presentation.calendardetailview.CalendarWeatherDetail">
     <FrameLayout
         android:id="@+id/fragment_container"
         android:layout_width="0dp"
@@ -59,7 +59,7 @@
         </FrameLayout>
 
         <Button
-            android:id="@+id/btn_calendardetailview_save"
+            android:id="@+id/btn_calendardetailview_modify"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginStart="331dp"

--- a/app/src/main/res/layout/fragment_calendar_modify_weather.xml
+++ b/app/src/main/res/layout/fragment_calendar_modify_weather.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.calendardetailview.CalendarModifyWeatherFragment">
+
+    <!-- TODO: Update blank fragment layout -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="@string/hello_blank_fragment" />
+
+</FrameLayout>


### PR DESCRIPTION
## 개요

>상세보기 일기가 없는 경우

## 작업 사항

- [x]  상세보기 일기가 없는 경우 빈 화면으로 텍스트 주석 처리
- [x] 파일명 변경, 메모 편집 프래그먼트창 추가
- [x] [remove] : 액티비티 두번 호출 오류 제거
- [x] [feat] : 메모 추가입력 후 이전 화면으로 돌아가는 기능

## 참고사항 및 스크린샷
