### PR TITLE
[feat/#418] 맡은 api 부분 요청 오류시 로그인 화면으로 이동하게 

### DIFF
--- a/app/src/main/java/com/umc/yourweather/presentation/calendar/CalendarDetail.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/calendar/CalendarDetail.kt
@@ -18,6 +18,7 @@ import com.umc.yourweather.presentation.adapter.CalendarDetailMemoContentAdapter
 import com.umc.yourweather.presentation.adapter.CalendarDetailMemoListAdapter
 import com.umc.yourweather.presentation.calendardetailview.CalendarPlusWeather
 import com.umc.yourweather.presentation.calendardetailview.CalendarWeatherDetail
+import com.umc.yourweather.presentation.sign.SignIn
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -112,6 +113,9 @@ class CalendarDetail : AppCompatActivity() {
                     "calendarDetail",
                     "onFailure 오류: ${t.message?.toString()}",
                 )
+                val mIntent = Intent(this@CalendarDetail, SignIn::class.java)
+                startActivity(mIntent)
+                finish()
             }
         })
     }

--- a/app/src/main/java/com/umc/yourweather/presentation/calendar/CalendarFragment.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/calendar/CalendarFragment.kt
@@ -1,5 +1,6 @@
 package com.umc.yourweather.presentation.calendar
 
+import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
@@ -15,6 +16,7 @@ import com.umc.yourweather.data.remote.response.MonthWeatherResponse
 import com.umc.yourweather.data.service.WeatherService
 import com.umc.yourweather.databinding.FragmentCalendarBinding
 import com.umc.yourweather.di.RetrofitImpl
+import com.umc.yourweather.presentation.sign.SignIn
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -96,9 +98,13 @@ class CalendarFragment : Fragment() {
                 @RequiresApi(Build.VERSION_CODES.O)
                 override fun onFailure(call: Call<BaseResponse<MonthResponse>>, t: Throwable) {
                     Toast.makeText(requireContext(), "네트워크 오류입니다. 인터넷 연결을 확인해주세요!", Toast.LENGTH_LONG).show()
-                    weatherData = emptyList()
-                    binding.ctCalendarCustom.initCalendar(year!!, month!!, dateList, weatherData)
+//                    weatherData = emptyList()
+//                    binding.ctCalendarCustom.initCalendar(year!!, month!!, dateList, weatherData)
                     Log.d("Calendar", "onFailure 에러: " + t.message.toString())
+                    val mIntent = Intent(requireActivity(), SignIn::class.java)
+                    requireActivity().startActivity(mIntent)
+                    // 현재 액티비티 종료
+                    requireActivity().finish()
                 }
             })
     }

--- a/app/src/main/java/com/umc/yourweather/presentation/mypage/MyPageWithdraw2.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/mypage/MyPageWithdraw2.kt
@@ -16,6 +16,7 @@ import com.umc.yourweather.databinding.ActivityMyPageWithdraw2Binding
 import com.umc.yourweather.di.App
 import com.umc.yourweather.di.RetrofitImpl
 import com.umc.yourweather.di.UserSharedPreferences
+import com.umc.yourweather.presentation.sign.SignIn
 import com.umc.yourweather.util.AlertDialogTwoBtn
 import retrofit2.Call
 import retrofit2.Callback
@@ -103,6 +104,9 @@ class MyPageWithdraw2 : AppCompatActivity() {
 
             override fun onFailure(call: Call<BaseResponse<UserResponse>>, t: Throwable) {
                 Log.d("WithDrawDebug", "onFailure")
+                val mIntent = Intent(this@MyPageWithdraw2, SignIn::class.java)
+                startActivity(mIntent)
+                finish()
             }
         })
     }

--- a/app/src/main/java/com/umc/yourweather/presentation/sign/FindPw.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/sign/FindPw.kt
@@ -68,6 +68,9 @@ class FindPw : AppCompatActivity() {
             override fun onFailure(call: Call<BaseResponse<VerifyEmailResponse>>, t: Throwable) {
                 // 네트워크 에러 처리
                 Log.d("VerifyEmailDebug", "네트워크 오류: " + t.message.toString())
+                val mIntent = Intent(this@FindPw, SignIn::class.java)
+                startActivity(mIntent)
+                finish()
             }
         })
     }
@@ -95,6 +98,9 @@ class FindPw : AppCompatActivity() {
             override fun onFailure(call: Call<BaseResponse<Unit>>, t: Throwable) {
                 // 네트워크 에러 처리
                 Log.d("SendEmailDebug", "네트워크 오류: " + t.message.toString())
+                val mIntent = Intent(this@FindPw, SignIn::class.java)
+                startActivity(mIntent)
+                finish()
             }
         })
     }

--- a/app/src/main/java/com/umc/yourweather/presentation/sign/FindPwEmail.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/sign/FindPwEmail.kt
@@ -100,6 +100,9 @@ class FindPwEmail : AppCompatActivity() {
             override fun onFailure(call: Call<BaseResponse<Boolean>>, t: Throwable) {
                 // 네트워크 에러 처리
                 Log.d("CertifyEmailDebug", "네트워크 오류: " + t.message.toString())
+                val mIntent = Intent(this@FindPwEmail, SignIn::class.java)
+                startActivity(mIntent)
+                finish()
             }
         })
     }
@@ -128,6 +131,9 @@ class FindPwEmail : AppCompatActivity() {
             override fun onFailure(call: Call<BaseResponse<Unit>>, t: Throwable) {
                 // 네트워크 에러 처리
                 Log.d("ResendEmailDebug", "네트워크 오류: " + t.message.toString())
+                val mIntent = Intent(this@FindPwEmail, SignIn::class.java)
+                startActivity(mIntent)
+                finish()
             }
         })
     }

--- a/app/src/main/java/com/umc/yourweather/presentation/sign/SignIn.kt
+++ b/app/src/main/java/com/umc/yourweather/presentation/sign/SignIn.kt
@@ -46,11 +46,11 @@ class SignIn : AppCompatActivity() {
         binding = ActivitySignInBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-//        if (App.token_prefs.accessToken != null) {
-//            val mIntent = Intent(this@SignIn, BottomNavi::class.java)
-//            startActivity(mIntent)
-//            finish()
-//        }
+        if (App.token_prefs.accessToken != null) {
+            val mIntent = Intent(this@SignIn, BottomNavi::class.java)
+            startActivity(mIntent)
+            finish()
+        }
 
         // 비밀번호 찾기로 이동
         binding.tvSigninBtnfindpw.setOnClickListener {


### PR DESCRIPTION
## 개요

> 맡은 api 부분 요청 오류시 로그인 화면으로 이동하게 

## 작업 사항

- [x] onFailure에  로그인 화면으로 이동하는 로직 추가

## 참고사항 및 스크린샷
